### PR TITLE
feat: add timg

### DIFF
--- a/systems/common/default.nix
+++ b/systems/common/default.nix
@@ -6,6 +6,7 @@
   imports = [
     ./boot.nix
     ./fonts.nix
+    ./images.nix
     ./impermanence.nix
     ./inputs.nix
     ./lix.nix

--- a/systems/common/images.nix
+++ b/systems/common/images.nix
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, ... }: {
+  environment.systemPackages = [
+    pkgs.timg # Display images in your terminal
+  ];
+}


### PR DESCRIPTION
We don't currently have a good image viewer. I've added timg as with the terminal here (ghostty) we can use kitty image protocol support.

I've installed it in common since as it should also be possible to use on servers by displaying block characters/etc.

I used this instead of viu as it can also display other filetypes such as pdfs.