### PR TITLE
ci: switch to using a GitHub bot account

### DIFF
--- a/.github/workflows/update-npins.yml
+++ b/.github/workflows/update-npins.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub token for RoboPâtissière
+        uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.CUSTOM_GITHUB_APP_ID }}
+          private-key: ${{ secrets.CUSTOM_GITHUB_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
 
       - name: Install Nix
@@ -42,7 +49,7 @@ jobs:
         with:
           branch: auto/update-npins
           commit-message: "chore: bump npins dependencies"
-          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           title: "chore: bump npins dependencies"
           body: |
             This is an automated npins dependency bump


### PR DESCRIPTION
When making commits, we should be using a bot account. This will prevent me from getting false attribution, make it easier for others to make changes to the workflow in the future and let me grey out the update commits with refined github.