### PR TITLE
ci: set RoboPâtissière as author and committer

### DIFF
--- a/.github/workflows/update-npins.yml
+++ b/.github/workflows/update-npins.yml
@@ -51,6 +51,8 @@ jobs:
           commit-message: "chore: bump npins dependencies"
           token: ${{ steps.generate-token.outputs.token }}
           title: "chore: bump npins dependencies"
+          author: "RoboPâtissière[bot] <213641064+robopatissiere[bot]@users.noreply.github.com>"
+          committer: "RoboPâtissière[bot] <213641064+robopatissiere[bot]@users.noreply.github.com>"
           body: |
             This is an automated npins dependency bump
 


### PR DESCRIPTION
Even though I got RoboPâtissière to make pull requests, commits were still created with me as the author and github-actions[bot] as the committer. I would really like RoboPâtissière to be fully credited for these commits.