### PR TITLE
feat: attach homes to systems

### DIFF
--- a/homes/default.nix
+++ b/homes/default.nix
@@ -12,6 +12,7 @@ in {
         home.homeDirectory = "/home/minion";
       }
       ./minion/direnv.nix
+      ./minion/ghostty.nix
       ./minion/ripgrep.nix
     ];
     args = {

--- a/homes/default.nix
+++ b/homes/default.nix
@@ -14,6 +14,7 @@ in {
       ./minion/direnv.nix
       ./minion/ghostty.nix
       ./minion/ripgrep.nix
+      ./minion/zoxide.nix
     ];
     args = {
       system = "x86_64-linux";

--- a/homes/minion/ghostty.nix
+++ b/homes/minion/ghostty.nix
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  programs.ghostty = {
+    enable = true;
+    settings.theme = "catppuccin-latte";
+  };
+}

--- a/homes/minion/zoxide.nix
+++ b/homes/minion/zoxide.nix
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  programs.zoxide = {
+    enable = true;
+    options = [ "--cmd=cd" "--hook=prompt" ];
+  };
+}

--- a/nilla.nix
+++ b/nilla.nix
@@ -18,6 +18,7 @@ in
       ./lib
       ./systems
       "${pins.nilla-home}/modules/home.nix" # We can't use config.inputs here without infinitely-recursing
+      "${pins.nilla-home}/modules/nixos.nix" # We can't use config.inputs here without infinitely-recursing
       "${pins.nilla-nixos}/modules/nixos.nix" # We can't use config.inputs here without infinitely-recursing
     ];
 

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -71,20 +71,17 @@
       "hash": "sha256-7EICjbmG6lApWKhFtwvZovdcdORY1CEe6/K7JwtpYfs="
     },
     "nilla": {
-      "type": "GitRelease",
+      "type": "Git",
       "repository": {
         "type": "GitHub",
         "owner": "nilla-nix",
         "repo": "nilla"
       },
-      "pre_releases": true,
-      "version_upper_bound": null,
-      "release_prefix": null,
+      "branch": "private/skyler/push-vsumrmrmvktt",
       "submodules": false,
-      "version": "v0.0.0-alpha.13",
-      "revision": "9070014ab7fcd0b6ef3b901a2047c06dcb975538",
-      "url": "https://api.github.com/repos/nilla-nix/nilla/tarball/v0.0.0-alpha.13",
-      "hash": "sha256-7iLzbTLtgdFtm9em3xxHO9BunN2YpgYquMLKXh5hEpQ="
+      "revision": "c780262b7d25208a7a4d6d4ea5bd6235412690b0",
+      "url": "https://github.com/nilla-nix/nilla/archive/c780262b7d25208a7a4d6d4ea5bd6235412690b0.tar.gz",
+      "hash": "sha256-OX3v2wv2bk/K3OlOc+3EgktmLSzWfufZ6yj3zGpfDd8="
     },
     "nilla-cli": {
       "type": "Git",
@@ -106,11 +103,11 @@
         "owner": "nilla-nix",
         "repo": "home"
       },
-      "branch": "private/skyler/push-unysrsvrnryq",
+      "branch": "private/skyler/push-mutykqtkuuwv",
       "submodules": false,
-      "revision": "8c908b6bccc0656af87539757af3952b9ab81993",
-      "url": "https://github.com/nilla-nix/home/archive/8c908b6bccc0656af87539757af3952b9ab81993.tar.gz",
-      "hash": "sha256-F6Uf8pYWaTnG37IziyXgfD2d56LKsZ6/i9Eu+sMii4M="
+      "revision": "2f3d8131e32bb3432e5f6e5f96a14ec5595b30fa",
+      "url": "https://github.com/nilla-nix/home/archive/2f3d8131e32bb3432e5f6e5f96a14ec5595b30fa.tar.gz",
+      "hash": "sha256-+AsmTE9b4gilAKzIL5kQlnc6W6Q26dF/OLDoFZcB4rw="
     },
     "nilla-nixos": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -23,11 +23,11 @@
         "owner": "nix-community",
         "repo": "home-manager"
       },
-      "branch": "master",
+      "branch": "release-25.05",
       "submodules": false,
-      "revision": "86b95fc1ed2b9b04a451a08ccf13d78fb421859c",
-      "url": "https://github.com/nix-community/home-manager/archive/86b95fc1ed2b9b04a451a08ccf13d78fb421859c.tar.gz",
-      "hash": "sha256-gGGLujmeWU+ZjFzfMvFMI0hp9xONsSbm88187wJr82Q="
+      "revision": "282e1e029cb6ab4811114fc85110613d72771dea",
+      "url": "https://github.com/nix-community/home-manager/archive/282e1e029cb6ab4811114fc85110613d72771dea.tar.gz",
+      "hash": "sha256-RMhjnPKWtCoIIHiuR9QKD7xfsKb3agxzMfJY8V9MOew="
     },
     "impermanence": {
       "type": "Git",

--- a/systems/default.nix
+++ b/systems/default.nix
@@ -16,6 +16,7 @@ in {
       system = "x86_64-linux";
       monorepo = config;
     };
+    homes = { inherit (config.homes) "minion:x86_64-linux"; };
   };
   config.systems.nixos."emden" = {
     pkgs = config.inputs.nixpkgs.result.x86_64-linux;
@@ -28,6 +29,7 @@ in {
       system = "x86_64-linux";
       monorepo = config;
     };
+    homes = { inherit (config.homes) "minion:x86_64-linux"; };
   };
   config.systems.nixos."midnight" = {
     pkgs = config.inputs.nixpkgs.result.x86_64-linux;

--- a/systems/personal/homes.nix
+++ b/systems/personal/homes.nix
@@ -3,8 +3,5 @@
 # SPDX-License-Identifier: MIT
 
 {
-  imports = [
-    ./configuration.nix
-    ./homes.nix
-  ];
+  home-manager.backupFileExtension = "backup";
 }


### PR DESCRIPTION
[feat: attach homes to systems](https://github.com/FreshlyBakedCake/PacketMix/commit/85416c372c421e0676b37724840f85ec853ec357)

I want to update homes with the existing OTA updates rather than
manually doing it. Attaching homes to systems with the new NixOS module
allows me to do this

This feature is currently unmerged in nilla-nix/home due to an aux lib
bug, so I've pinned the new home version as well as a nilla version to
update lib