### PR TITLE
refactor: rename monorepo to project

### DIFF
--- a/homes/default.nix
+++ b/homes/default.nix
@@ -18,7 +18,7 @@ in {
     ];
     args = {
       system = "x86_64-linux";
-      monorepo = config;
+      project = config;
     };
   };
 }

--- a/systems/common/inputs.nix
+++ b/systems/common/inputs.nix
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ monorepo, pkgs, lib, ... }: {
+{ project, pkgs, lib, ... }: {
   nix = {
     channel.enable = false;
     nixPath = [ "/etc/nix/inputs" ];
@@ -16,5 +16,5 @@
     value.source = if (lib.strings.isStringLike value.result) && (lib.strings.hasPrefix builtins.storeDir (builtins.toString value.result)) # We convert to a string here to force paths out of any attrsets/etc.
                    then builtins.storePath value.result
                    else builtins.storePath value.src;
-  }) monorepo.inputs;
+  }) project.inputs;
 }

--- a/systems/common/lix.nix
+++ b/systems/common/lix.nix
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ monorepo, ... }: {
+{ project, ... }: {
   imports = [
-    (import "${monorepo.inputs.lix-module.result}/module.nix" { lix = monorepo.inputs.lix.src; })
+    (import "${project.inputs.lix-module.result}/module.nix" { lix = project.inputs.lix.src; })
   ];
 
   nix.settings.experimental-features = [ "nix-command" ];

--- a/systems/common/nilla-nix.nix
+++ b/systems/common/nilla-nix.nix
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ monorepo, system, ... }: {
+{ project, system, ... }: {
   environment.systemPackages = [
-    monorepo.inputs.nilla-cli.result.packages.nilla-cli.result.${system}
-    monorepo.inputs.nilla-home.result.packages.nilla-home.result.${system}
-    monorepo.inputs.nilla-nixos.result.packages.nilla-nixos.result.${system}
+    project.inputs.nilla-cli.result.packages.nilla-cli.result.${system}
+    project.inputs.nilla-home.result.packages.nilla-home.result.${system}
+    project.inputs.nilla-nixos.result.packages.nilla-nixos.result.${system}
   ];
 }

--- a/systems/default.nix
+++ b/systems/default.nix
@@ -14,7 +14,7 @@ in {
     ];
     args = {
       system = "x86_64-linux";
-      monorepo = config;
+      project = config;
     };
     homes = { inherit (config.homes) "minion:x86_64-linux"; };
   };
@@ -27,7 +27,7 @@ in {
     ];
     args = {
       system = "x86_64-linux";
-      monorepo = config;
+      project = config;
     };
     homes = { inherit (config.homes) "minion:x86_64-linux"; };
   };
@@ -40,7 +40,7 @@ in {
     ];
     args = {
       system = "x86_64-linux";
-      monorepo = config;
+      project = config;
     };
   };
   config.systems.nixos."teal" = {
@@ -52,7 +52,7 @@ in {
     ];
     args = {
       system = "x86_64-linux";
-      monorepo = config;
+      project = config;
     };
   };
 }

--- a/systems/personal/configuration.nix
+++ b/systems/personal/configuration.nix
@@ -6,7 +6,7 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-{ monorepo, config, system, pkgs, ... }:
+{ project, config, system, pkgs, ... }:
 {
   # Enable networking
   networking.networkmanager.enable = true;
@@ -122,7 +122,7 @@
     }))
     dogdns
     ghostty
-    (monorepo.inputs.npins.result { inherit pkgs system; })
+    (project.inputs.npins.result { inherit pkgs system; })
     thunderbird
     difftastic
     meld

--- a/systems/server/default.nix
+++ b/systems/server/default.nix
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ monorepo, ... }: {
+{ project, ... }: {
   imports = [
-    monorepo.inputs.impermanence.result.nixosModules.impermanence
+    project.inputs.impermanence.result.nixosModules.impermanence
     ./locale.nix
     ./ssh.nix
   ];


### PR DESCRIPTION
This isn't a monorepo, so it doesn't make that much sense to call it monorepo- let's call it "project" instead