### PR TITLE
feat: retry failed auto-updates

### DIFF
--- a/systems/common/packetmix.nix
+++ b/systems/common/packetmix.nix
@@ -23,10 +23,19 @@
   };
 
   systemd.services.nixos-upgrade.preStart = ''
+    ${pkgs.networkmanager}/bin/nm-online -s -q # wait until the internet is online, as esp. if we go offline we need to wait to retry...
     cd /etc/nixos
     ${pkgs.git}/bin/git fetch
     ${pkgs.git}/bin/git checkout origin/release
   '';
+
+  systemd.services.nixos-upgrade.serviceConfig = {
+    Restart = "on-failure";
+    RestartSec = 5;
+    RestartSteps = 5;
+    RestartMaxDelaySec = 86400;
+  };
+    
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions


### PR DESCRIPTION
It's fairly common for my laptop to fail auto-updating as it is off the network. We can improve its chances by retrying auto-updates that fail, and backing off if we're continuously failing. I pulled some random numbers that look plausible for min/max/etc. delay: 5 seconds to 1 day with some relatively small scaling steps. Since as this service will also already be started once a day, I don't expect to ever reach the high end (though there was some discussion about 1/week on servers(?))

Additionally, I've made the network wait until it is online using networkmanager before it updates, since as the network being offline at the start is by-far the largest reason for this to fail by my observation (much more than config failures or dropping in the middle)

We should also set up notification of failed updates as soon as we have a notification daemon