### PR TITLE
feat: add javelin udev rules

### DIFF
--- a/systems/default.nix
+++ b/systems/default.nix
@@ -9,6 +9,7 @@ in {
     pkgs = config.inputs.nixpkgs.result.x86_64-linux;
     modules = [
       ./common
+      ./javelin
       ./niri
       ./personal
       ./redhead
@@ -23,6 +24,7 @@ in {
     pkgs = config.inputs.nixpkgs.result.x86_64-linux;
     modules = [
       ./common
+      ./javelin
       ./emden
       ./niri
       ./personal

--- a/systems/javelin/default.nix
+++ b/systems/javelin/default.nix
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  imports = [
+    ./udev.nix
+  ];
+}

--- a/systems/javelin/udev.nix
+++ b/systems/javelin/udev.nix
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  services.udev.extraRules = ''
+    SUBSYSTEM=="hidraw", ATTRS{idVendor}=="9000", ATTRS{idProduct}=="400d", MODE="0666"
+  '';
+}


### PR DESCRIPTION
Javelin is the firmware I use on my keyboard. I need these udev rules to configure it via the online tool at https://lim.au/