### PR TITLE
feat: add bluetooth

### DIFF
--- a/systems/personal/bluetooth.nix
+++ b/systems/personal/bluetooth.nix
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, ... }: {
+  environment.systemPackages = [ pkgs.overskride ];
+
+  hardware.bluetooth.enable = true;
+}

--- a/systems/personal/default.nix
+++ b/systems/personal/default.nix
@@ -4,6 +4,7 @@
 
 {
   imports = [
+    ./bluetooth.nix
     ./configuration.nix
     ./homes.nix
   ];


### PR DESCRIPTION
When we removed gnome, we didn't install anything to control bluetooth.

I still need it, so let's add it back