### PR TITLE
feat: install sd

### DIFF
--- a/homes/default.nix
+++ b/homes/default.nix
@@ -15,6 +15,7 @@ in {
       ./minion/ghostty.nix
       (import ./minion/niri.nix { inherit (config.inputs) niri walker; })
       ./minion/ripgrep.nix
+      ./minion/sd.nix
       ./minion/zoxide.nix
     ];
     args = {

--- a/homes/minion/sd.nix
+++ b/homes/minion/sd.nix
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, ... }: {
+  home.packages = [ pkgs.sd ];
+}


### PR DESCRIPTION
sd is a package that can do substitutions - in many ways it feels to sed what ripgrep is to grep. I would very much like to compose it with helix to have proper regex find/replace (i.e. by using '|sd ... ...' in helix)