### PR TITLE
feat: add helix config

### DIFF
--- a/LICENSES/MPL-2.0.txt
+++ b/LICENSES/MPL-2.0.txt
@@ -1,0 +1,144 @@
+Mozilla Public License Version 2.0 
+
+1. Definitions
+
+     1.1. "Contributor" means each individual or legal entity that creates, contributes to the creation of, or owns Covered Software.
+
+     1.2. "Contributor Version" means the combination of the Contributions of others (if any) used by a Contributor and that particular Contributor's Contribution.
+
+     1.3. "Contribution" means Covered Software of a particular Contributor.
+
+     1.4. "Covered Software" means Source Code Form to which the initial Contributor has attached the notice in Exhibit A, the Executable Form of such Source Code Form, and Modifications of such Source Code Form, in each case including portions thereof.
+
+     1.5. "Incompatible With Secondary Licenses" means
+
+          (a) that the initial Contributor has attached the notice described in Exhibit B to the Covered Software; or
+
+          (b) that the Covered Software was made available under the terms of version 1.1 or earlier of the License, but not also under the terms of a Secondary License.
+
+     1.6. "Executable Form" means any form of the work other than Source Code Form.
+
+     1.7. "Larger Work" means a work that combines Covered Software with other material, in a separate file or files, that is not Covered Software.
+
+     1.8. "License" means this document.
+
+     1.9. "Licensable" means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently, any and all of the rights conveyed by this License.
+
+     1.10. "Modifications" means any of the following:
+
+          (a) any file in Source Code Form that results from an addition to, deletion from, or modification of the contents of Covered Software; or
+
+          (b) any new file in Source Code Form that contains any Covered Software.
+
+     1.11. "Patent Claims" of a Contributor means any patent claim(s), including without limitation, method, process, and apparatus claims, in any patent Licensable by such Contributor that would be infringed, but for the grant of the License, by the making, using, selling, offering for sale, having made, import, or transfer of either its Contributions or its Contributor Version.
+
+     1.12. "Secondary License" means either the GNU General Public License, Version 2.0, the GNU Lesser General Public License, Version 2.1, the GNU Affero General Public License, Version 3.0, or any later versions of those licenses.
+
+     1.13. "Source Code Form" means the form of the work preferred for making modifications.
+
+     1.14. "You" (or "Your") means an individual or a legal entity exercising rights under this License. For legal entities, "You" includes any entity that controls, is controlled by, or is under common control with You. For purposes of this definition, "control" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+
+2. License Grants and Conditions 
+
+     2.1. Grants
+     Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+          (a) under intellectual property rights (other than patent or trademark) Licensable by such Contributor to use, reproduce, make available, modify, display, perform, distribute, and otherwise exploit its Contributions, either on an unmodified basis, with Modifications, or as part of a Larger Work; and
+
+          (b) under Patent Claims of such Contributor to make, use, sell, offer for sale, have made, import, and otherwise transfer either its Contributions or its Contributor Version.
+
+     2.2. Effective Date
+     The licenses granted in Section 2.1 with respect to any Contribution become effective for each Contribution on the date the Contributor first distributes such Contribution.
+
+     2.3. Limitations on Grant Scope
+     The licenses granted in this Section 2 are the only rights granted under this License. No additional rights or licenses will be implied from the distribution or licensing of Covered Software under this License. Notwithstanding Section 2.1(b) above, no patent license is granted by a Contributor:
+
+          (a) for any code that a Contributor has removed from Covered Software; or
+
+          (b) for infringements caused by: (i) Your and any other third party's modifications of Covered Software, or (ii) the combination of its Contributions with other software (except as part of its Contributor Version); or
+
+          (c) under Patent Claims infringed by Covered Software in the absence of its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks, or logos of any Contributor (except as may be necessary to comply with the notice requirements in Section 3.4).
+
+     2.4. Subsequent Licenses
+     No Contributor makes additional grants as a result of Your choice to distribute the Covered Software under a subsequent version of this License (see Section 10.2) or under the terms of a Secondary License (if permitted under the terms of Section 3.3).
+
+     2.5. Representation
+     Each Contributor represents that the Contributor believes its Contributions are its original creation(s) or it has sufficient rights to grant the rights to its Contributions conveyed by this License.
+
+     2.6. Fair Use
+     This License is not intended to limit any rights You have under applicable copyright doctrines of fair use, fair dealing, or other equivalents.
+
+     2.7. Conditions
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in Section 2.1.
+
+3. Responsibilities
+
+     3.1. Distribution of Source Form
+     All distribution of Covered Software in Source Code Form, including any Modifications that You create or to which You contribute, must be under the terms of this License. You must inform recipients that the Source Code Form of the Covered Software is governed by the terms of this License, and how they can obtain a copy of this License. You may not attempt to alter or restrict the recipients' rights in the Source Code Form.
+
+     3.2. Distribution of Executable Form
+     If You distribute Covered Software in Executable Form then:
+
+          (a) such Covered Software must also be made available in Source Code Form, as described in Section 3.1, and You must inform recipients of the Executable Form how they can obtain a copy of such Source Code Form by reasonable means in a timely manner, at a charge no more than the cost of distribution to the recipient; and
+
+          (b) You may distribute such Executable Form under the terms of this License, or sublicense it under different terms, provided that the license for the Executable Form does not attempt to limit or alter the recipients' rights in the Source Code Form under this License.
+
+     3.3. Distribution of a Larger Work
+     You may create and distribute a Larger Work under terms of Your choice, provided that You also comply with the requirements of this License for the Covered Software. If the Larger Work is a combination of Covered Software with a work governed by one or more Secondary Licenses, and the Covered Software is not Incompatible With Secondary Licenses, this License permits You to additionally distribute such Covered Software under the terms of such Secondary License(s), so that the recipient of the Larger Work may, at their option, further distribute the Covered Software under the terms of either this License or such Secondary License(s).
+
+     3.4. Notices
+     You may not remove or alter the substance of any license notices (including copyright notices, patent notices, disclaimers of warranty, or limitations of liability) contained within the Source Code Form of the Covered Software, except that You may alter any license notices to the extent required to remedy known factual inaccuracies.
+ 
+     3.5. Application of Additional Terms
+     You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Software. However, You may do so only on Your own behalf, and not on behalf of any Contributor. You must make it absolutely clear that any such warranty, support, indemnity, or liability obligation is offered by You alone, and You hereby agree to indemnify every Contributor for any liability incurred by such Contributor as a result of warranty, support, indemnity or liability terms You offer. You may include additional disclaimers of warranty and limitations of liability specific to any jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation 
+If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Software due to statute, judicial order, or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be placed in a text file included with all distributions of the Covered Software under this License. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.
+
+5. Termination 
+
+     5.1. The rights granted under this License will terminate automatically if You fail to comply with any of its terms. However, if You become compliant, then the rights granted under this License from a particular Contributor are reinstated (a) provisionally, unless and until such Contributor explicitly and finally terminates Your grants, and (b) on an ongoing basis, if such Contributor fails to notify You of the non-compliance by some reasonable means prior to 60 days after You have come back into compliance. Moreover, Your grants from a particular Contributor are reinstated on an ongoing basis if such Contributor notifies You of the non-compliance by some reasonable means, this is the first time You have received notice of non-compliance with this License from such Contributor, and You become compliant prior to 30 days after Your receipt of the notice.
+
+     5.2. If You initiate litigation against any entity by asserting a patent infringement claim (excluding declaratory judgment actions, counter-claims, and cross-claims) alleging that a Contributor Version directly or indirectly infringes any patent, then the rights granted to You by any and all Contributors for the Covered Software under Section 2.1 of this License shall terminate.
+
+     5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user license agreements (excluding distributors and resellers) which have been validly granted by You or Your distributors under this License prior to termination shall survive termination.
+
+6. Disclaimer of Warranty 
+Covered Software is provided under this License on an "as is" basis, without warranty of any kind, either expressed, implied, or statutory, including, without limitation, warranties that the Covered Software is free of defects, merchantable, fit for a particular purpose or non-infringing. The entire risk as to the quality and performance of the Covered Software is with You. Should any Covered Software prove defective in any respect, You (not any Contributor) assume the cost of any necessary servicing, repair, or correction. This disclaimer of warranty constitutes an essential part of this License. No use of any Covered Software is authorized under this License except under this disclaimer. 
+
+7. Limitation of Liability 
+Under no circumstances and under no legal theory, whether tort (including negligence), contract, or otherwise, shall any Contributor, or anyone who distributes Covered Software as permitted above, be liable to You for any direct, indirect, special, incidental, or consequential damages of any character including, without limitation, damages for lost profits, loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses, even if such party shall have been informed of the possibility of such damages. This limitation of liability shall not apply to liability for death or personal injury resulting from such party's negligence to the extent applicable law prohibits such limitation. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to You. 
+
+8. Litigation 
+Any litigation relating to this License may be brought only in the courts of a jurisdiction where the defendant maintains its principal place of business and such litigation shall be governed by laws of that jurisdiction, without reference to its conflict-of-law provisions. Nothing in this Section shall prevent a party's ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous 
+This License represents the complete agreement concerning the subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not be used to construe this License against a Contributor.
+
+10. Versions of the License 
+
+     10.1. New Versions
+     Mozilla Foundation is the license steward. Except as provided in Section 10.3, no one other than the license steward has the right to modify or publish new versions of this License. Each version will be given a distinguishing version number.
+
+     10.2. Effect of New Versions
+     You may distribute the Covered Software under the terms of the version of the License under which You originally received the Covered Software, or under the terms of any subsequent version published by the license steward.
+
+     10.3. Modified Versions
+     If you create software not governed by this License, and you want to create a new license for such software, you may create and use a modified version of this License if you rename the license and remove any references to the name of the license steward (except to note that such modified license differs from this License).
+
+     10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+     If You choose to distribute Source Code Form that is Incompatible With Secondary Licenses under the terms of this version of the License, the notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice 
+
+     This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice 
+
+     This Source Code Form is "Incompatible With Secondary Licenses", as defined by the Mozilla Public License, v. 2.0.

--- a/homes/default.nix
+++ b/homes/default.nix
@@ -13,6 +13,7 @@ in {
       }
       ./minion/direnv.nix
       ./minion/ghostty.nix
+      ./minion/helix.nix
       (import ./minion/niri.nix { inherit (config.inputs) niri walker; })
       ./minion/ripgrep.nix
       ./minion/sd.nix

--- a/homes/minion/helix.nix
+++ b/homes/minion/helix.nix
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  pkgs,
+  project,
+  system,
+  ...
+}:
+{
+  programs.helix = {
+    enable = true;
+
+    package = project.packages.helix.result.${system};
+
+    settings = {
+      theme = "catppuccin_latte";
+
+      editor = {
+        bufferline = "multiple";
+
+        line-number = "relative";
+        lsp.display-inlay-hints = true;
+
+        end-of-line-diagnostics = "hint";
+        inline-diagnostics = {
+          cursor-line = "warning";
+          other-lines = "error";
+        };
+      };
+
+      keys.normal = {
+        space.E = {
+          command = "@mip<space>e";
+          label = "Hard-wrap (rEflow) current paragraph";
+        };
+        space.e = {
+          command = ":reflow";
+          label = "Hard-wrap (rEflow) selected text";
+        };
+      };
+    };
+
+    languages = {
+      language = [
+        {
+          name = "nix";
+          formatter = {
+            command = "${pkgs.nixfmt-rfc-style}/bin/nixfmt";
+          };
+        }
+      ];
+    };
+  };
+}

--- a/nilla.nix
+++ b/nilla.nix
@@ -63,6 +63,14 @@ in
         };
       };
 
+      packages.helix = {
+        systems = [ "x86_64-linux" ];
+
+        package = { helix }: helix.overrideAttrs ({ patches ? [], ... }: {
+          patches = patches ++ [ ./patches/helix/3958-labels-for-config-menus.patch ];
+        });
+      };
+
       # With a package set defined, we can create a shell.
       shells.default = {
         # Declare what systems the shell can be used on.

--- a/patches/helix/3958-labels-for-config-menus.patch
+++ b/patches/helix/3958-labels-for-config-menus.patch
@@ -1,0 +1,928 @@
+From c92e341ee42b33c4c6dcb4e8287a12c03434c164 Mon Sep 17 00:00:00 2001
+From: Matthew Cheely <matt_cheely@fastmail.com>
+Date: Fri, 23 Sep 2022 21:37:23 -0400
+Subject: [PATCH 01/15] Add support for labels in custom menu keymaps
+
+---
+ helix-term/src/config.rs | 33 +++++++++++++++++++++++++++++++++
+ helix-term/src/keymap.rs | 17 +++++++++++++----
+ 2 files changed, 46 insertions(+), 4 deletions(-)
+
+diff --git a/helix-term/src/config.rs b/helix-term/src/config.rs
+index bcba8d8e1d45..91738f3ef562 100644
+--- a/helix-term/src/config.rs
++++ b/helix-term/src/config.rs
+@@ -174,6 +174,39 @@ mod tests {
+         );
+     }
+ 
++    #[test]
++    fn parsing_menus() {
++        use crate::keymap;
++        use crate::keymap::Keymap;
++        use helix_core::hashmap;
++        use helix_view::document::Mode;
++
++        let sample_keymaps = r#"
++            [keys.normal]
++            f = { f = "file_picker", c = "wclose" }
++            b = { label = "buffer", b = "buffer_picker", n = "goto_next_buffer" }
++        "#;
++
++        assert_eq!(
++            toml::from_str::<Config>(sample_keymaps).unwrap(),
++            Config {
++                keys: hashmap! {
++                    Mode::Normal => Keymap::new(keymap!({ "Normal mode"
++                        "f" => { ""
++                            "f" => file_picker,
++                            "c" => wclose,
++                        },
++                        "b" => { "buffer"
++                            "b" => buffer_picker,
++                            "n" => goto_next_buffer,
++                        },
++                    })),
++                },
++                ..Default::default()
++            }
++        );
++    }
++
+     #[test]
+     fn keys_resolve_to_correct_defaults() {
+         // From serde default
+diff --git a/helix-term/src/keymap.rs b/helix-term/src/keymap.rs
+index 020ecaf40f0f..01abd708604e 100644
+--- a/helix-term/src/keymap.rs
++++ b/helix-term/src/keymap.rs
+@@ -197,13 +197,22 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+     where
+         M: serde::de::MapAccess<'de>,
+     {
++        let mut name = "";
+         let mut mapping = HashMap::new();
+         let mut order = Vec::new();
+-        while let Some((key, value)) = map.next_entry::<KeyEvent, KeyTrie>()? {
+-            mapping.insert(key, value);
+-            order.push(key);
++
++        while let Some(key) = map.next_key::<&str>()? {
++            match key {
++                "label" => name = map.next_value::<&str>()?,
++                _ => {
++                    let key_event = key.parse::<KeyEvent>().map_err(serde::de::Error::custom)?;
++                    let key_trie = map.next_value::<KeyTrie>()?;
++                    mapping.insert(key_event, key_trie);
++                    order.push(key_event);
++                }
++            }
+         }
+-        Ok(KeyTrie::Node(KeyTrieNode::new("", mapping, order)))
++        Ok(KeyTrie::Node(KeyTrieNode::new(name, mapping, order)))
+     }
+ }
+ 
+
+From be13c26c803ce887fec065ecf817306e89022f1e Mon Sep 17 00:00:00 2001
+From: Matthew Cheely <matt_cheely@fastmail.com>
+Date: Fri, 23 Sep 2022 23:03:56 -0400
+Subject: [PATCH 02/15] Add support for labels on typable commands
+
+---
+ helix-term/src/config.rs | 38 ++++++++++++++++++++++++++++++++++++++
+ helix-term/src/keymap.rs | 28 +++++++++++++++++++++++++---
+ 2 files changed, 63 insertions(+), 3 deletions(-)
+
+diff --git a/helix-term/src/config.rs b/helix-term/src/config.rs
+index 91738f3ef562..92b4fb8565ce 100644
+--- a/helix-term/src/config.rs
++++ b/helix-term/src/config.rs
+@@ -207,6 +207,44 @@ mod tests {
+         );
+     }
+ 
++    #[test]
++    fn parsing_typable_commands() {
++        use crate::keymap;
++        use crate::keymap::MappableCommand;
++        use helix_view::document::Mode;
++        use helix_view::input::KeyEvent;
++        use std::str::FromStr;
++
++        let sample_keymaps = r#"
++            [keys.normal]
++            o = { label = "Edit Config", command = ":open ~/.config" }
++            c = ":buffer-close" 
++        "#;
++
++        let config = toml::from_str::<Config>(sample_keymaps).unwrap();
++
++        let tree = config.keys.get(&Mode::Normal).unwrap().root();
++
++        if let keymap::KeyTrie::Node(node) = tree {
++            let open_node = node.get(&KeyEvent::from_str("o").unwrap()).unwrap();
++
++            if let keymap::KeyTrie::Leaf(MappableCommand::Typable { doc, .. }) = open_node {
++                assert_eq!(doc, "Edit Config");
++            } else {
++                panic!("Edit Config did not parse to typable command");
++            }
++
++            let close_node = node.get(&KeyEvent::from_str("c").unwrap()).unwrap();
++            if let keymap::KeyTrie::Leaf(MappableCommand::Typable { doc, .. }) = close_node {
++                assert_eq!(doc, ":buffer-close []");
++            } else {
++                panic!(":buffer-close command did not parse to typable command");
++            }
++        } else {
++            panic!("Config did not parse to trie");
++        }
++    }
++
+     #[test]
+     fn keys_resolve_to_correct_defaults() {
+         // From serde default
+diff --git a/helix-term/src/keymap.rs b/helix-term/src/keymap.rs
+index 01abd708604e..f157e2fee0dc 100644
+--- a/helix-term/src/keymap.rs
++++ b/helix-term/src/keymap.rs
+@@ -197,13 +197,15 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+     where
+         M: serde::de::MapAccess<'de>,
+     {
+-        let mut name = "";
++        let mut label = "";
++        let mut command = None;
+         let mut mapping = HashMap::new();
+         let mut order = Vec::new();
+ 
+         while let Some(key) = map.next_key::<&str>()? {
+             match key {
+-                "label" => name = map.next_value::<&str>()?,
++                "label" => label = map.next_value::<&str>()?,
++                "command" => command = Some(map.next_value::<MappableCommand>()?),
+                 _ => {
+                     let key_event = key.parse::<KeyEvent>().map_err(serde::de::Error::custom)?;
+                     let key_trie = map.next_value::<KeyTrie>()?;
+@@ -212,7 +214,27 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+                 }
+             }
+         }
+-        Ok(KeyTrie::Node(KeyTrieNode::new(name, mapping, order)))
++
++        match command {
++            None => Ok(KeyTrie::Node(KeyTrieNode::new(label, mapping, order))),
++            Some(cmd) => {
++                if label.is_empty() {
++                    Ok(KeyTrie::Leaf(cmd))
++                } else {
++                    match cmd {
++                        MappableCommand::Typable { name, args, .. } => {
++                            Ok(MappableCommand::Typable {
++                                name,
++                                args,
++                                doc: label.to_string(),
++                            })
++                            .map(KeyTrie::Leaf)
++                        }
++                        MappableCommand::Static { .. } => Ok(KeyTrie::Leaf(cmd)),
++                    }
++                }
++            }
++        }
+     }
+ }
+ 
+
+From 73d8700f601fd0e8bedd19daf1bb094e1e5c0d0b Mon Sep 17 00:00:00 2001
+From: Matthew Cheely <matt_cheely@fastmail.com>
+Date: Sat, 24 Sep 2022 21:31:15 -0400
+Subject: [PATCH 03/15] refactor keymap map visitor to reduce # of cases
+
+---
+ helix-term/src/keymap.rs | 22 +++++++++-------------
+ 1 file changed, 9 insertions(+), 13 deletions(-)
+
+diff --git a/helix-term/src/keymap.rs b/helix-term/src/keymap.rs
+index f157e2fee0dc..98521eb3de08 100644
+--- a/helix-term/src/keymap.rs
++++ b/helix-term/src/keymap.rs
+@@ -218,20 +218,16 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+         match command {
+             None => Ok(KeyTrie::Node(KeyTrieNode::new(label, mapping, order))),
+             Some(cmd) => {
+-                if label.is_empty() {
+-                    Ok(KeyTrie::Leaf(cmd))
++                let status = (cmd, label.is_empty());
++                if let (MappableCommand::Typable { name, args, .. }, false) = status {
++                    Ok(MappableCommand::Typable {
++                        name,
++                        args,
++                        doc: label.to_string(),
++                    })
++                    .map(KeyTrie::Leaf)
+                 } else {
+-                    match cmd {
+-                        MappableCommand::Typable { name, args, .. } => {
+-                            Ok(MappableCommand::Typable {
+-                                name,
+-                                args,
+-                                doc: label.to_string(),
+-                            })
+-                            .map(KeyTrie::Leaf)
+-                        }
+-                        MappableCommand::Static { .. } => Ok(KeyTrie::Leaf(cmd)),
+-                    }
++                    Ok(KeyTrie::Leaf(status.0))
+                 }
+             }
+         }
+
+From a1c746cdb98a3d492bd81c2d80def81d45463091 Mon Sep 17 00:00:00 2001
+From: Matthew Cheely <matt_cheely@fastmail.com>
+Date: Tue, 4 Oct 2022 19:18:22 -0400
+Subject: [PATCH 04/15] Simplify labelled command pattern match
+
+Co-authored-by: Michael Davis <mcarsondavis@gmail.com>
+---
+ helix-term/src/keymap.rs | 19 +++++++------------
+ 1 file changed, 7 insertions(+), 12 deletions(-)
+
+diff --git a/helix-term/src/keymap.rs b/helix-term/src/keymap.rs
+index 98521eb3de08..cdad51a32567 100644
+--- a/helix-term/src/keymap.rs
++++ b/helix-term/src/keymap.rs
+@@ -217,19 +217,14 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+ 
+         match command {
+             None => Ok(KeyTrie::Node(KeyTrieNode::new(label, mapping, order))),
+-            Some(cmd) => {
+-                let status = (cmd, label.is_empty());
+-                if let (MappableCommand::Typable { name, args, .. }, false) = status {
+-                    Ok(MappableCommand::Typable {
+-                        name,
+-                        args,
+-                        doc: label.to_string(),
+-                    })
+-                    .map(KeyTrie::Leaf)
+-                } else {
+-                    Ok(KeyTrie::Leaf(status.0))
+-                }
++            Some(MappableCommand::Typable { name, args, .. }) if !label.is_empty() => {
++                Ok(KeyTrie::Leaf(MappableCommand::Typable {
++                    name,
++                    args,
++                    doc: label.to_string(),
++                }))
+             }
++            Some(command) => Ok(KeyTrie::Leaf(command)),
+         }
+     }
+ }
+
+From 789af1ec9fb522a4f3ef70f19f001729a6a0dd25 Mon Sep 17 00:00:00 2001
+From: Matthew Cheely <matt_cheely@fastmail.com>
+Date: Mon, 17 Oct 2022 20:15:27 -0400
+Subject: [PATCH 05/15] Add some basic docs
+
+---
+ book/src/remapping.md | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/book/src/remapping.md b/book/src/remapping.md
+index e3efdf16f851..a0c8acada596 100644
+--- a/book/src/remapping.md
++++ b/book/src/remapping.md
+@@ -19,6 +19,13 @@ w = "move_line_up" # Maps the 'w' key move_line_up
+ g = { a = "code_action" } # Maps `ga` to show possible code actions
+ "ret" = ["open_below", "normal_mode"] # Maps the enter key to open_below then re-enter normal mode
+ 
++# You can create labeled sub-menus and provide friendly labels for typeable commands
++[keys.normal.space.f] # Registering multiple mappings under a single entry creates a sub-menu (accesed by 'space', 'f' in this case)
++label = "File" # The menu is called file and within  it:
++f = "file_picker" # 'f' opens the file picker
++s = { label = "Save", command = ":write" } # 's' saves the current file
++c = { label = "Edit Config", command = ":open ~/.config/helix/config.toml" } # 'c' opens the helix config file
++
+ [keys.insert]
+ "A-x" = "normal_mode"     # Maps Alt-X to enter normal mode
+ j = { k = "normal_mode" } # Maps `jk` to exit insert mode
+
+From c1b77b541803a41a2aa0a96a000993eb68b03ef7 Mon Sep 17 00:00:00 2001
+From: Matthew Cheely <matt_cheely@fastmail.com>
+Date: Tue, 15 Nov 2022 18:42:36 -0500
+Subject: [PATCH 06/15] fix typos in menu label docs
+
+---
+ book/src/remapping.md | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/book/src/remapping.md b/book/src/remapping.md
+index a0c8acada596..4fb92109e448 100644
+--- a/book/src/remapping.md
++++ b/book/src/remapping.md
+@@ -20,8 +20,8 @@ g = { a = "code_action" } # Maps `ga` to show possible code actions
+ "ret" = ["open_below", "normal_mode"] # Maps the enter key to open_below then re-enter normal mode
+ 
+ # You can create labeled sub-menus and provide friendly labels for typeable commands
+-[keys.normal.space.f] # Registering multiple mappings under a single entry creates a sub-menu (accesed by 'space', 'f' in this case)
+-label = "File" # The menu is called file and within  it:
++[keys.normal.space.f] # Registering multiple mappings under a single entry creates a sub-menu (accessed by 'space', 'f' in this case)
++label = "File" # The menu is called file and within it:
+ f = "file_picker" # 'f' opens the file picker
+ s = { label = "Save", command = ":write" } # 's' saves the current file
+ c = { label = "Edit Config", command = ":open ~/.config/helix/config.toml" } # 'c' opens the helix config file
+
+From fa8c2372b359674dc1874561351701b95b1b8d02 Mon Sep 17 00:00:00 2001
+From: Matthew Cheely <matt_cheely@fastmail.com>
+Date: Tue, 15 Nov 2022 21:20:39 -0500
+Subject: [PATCH 07/15] return errors for ambiguous and unsupported labels in
+ menus
+
+---
+ helix-term/src/keymap.rs | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/helix-term/src/keymap.rs b/helix-term/src/keymap.rs
+index cdad51a32567..d4eb41176de6 100644
+--- a/helix-term/src/keymap.rs
++++ b/helix-term/src/keymap.rs
+@@ -217,6 +217,12 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+ 
+         match command {
+             None => Ok(KeyTrie::Node(KeyTrieNode::new(label, mapping, order))),
++            Some(_command) if !order.is_empty() => {
++                Err(serde::de::Error::custom("ambiguous mapping: 'command' is only valid with 'label', but I found other keys"))
++            }
++            Some(MappableCommand::Static { .. }) if !label.is_empty() => {
++                Err(serde::de::Error::custom("custom labels are only available for typable commands (the ones starting with ':')"))
++            }
+             Some(MappableCommand::Typable { name, args, .. }) if !label.is_empty() => {
+                 Ok(KeyTrie::Leaf(MappableCommand::Typable {
+                     name,
+
+From fb649610ebd6097789a64a5013d2cb1ef6f04de6 Mon Sep 17 00:00:00 2001
+From: Matthew Cheely <matt_cheely@fastmail.com>
+Date: Sat, 10 Jun 2023 19:31:36 -0400
+Subject: [PATCH 08/15] Fix runtime config parse issues after rebase on latest
+ master
+
+---
+ helix-term/src/config.rs | 34 ++++++++++++++++++++--------------
+ helix-term/src/keymap.rs | 10 +++++-----
+ 2 files changed, 25 insertions(+), 19 deletions(-)
+
+diff --git a/helix-term/src/config.rs b/helix-term/src/config.rs
+index 92b4fb8565ce..0363311c4d5a 100644
+--- a/helix-term/src/config.rs
++++ b/helix-term/src/config.rs
+@@ -187,21 +187,27 @@ mod tests {
+             b = { label = "buffer", b = "buffer_picker", n = "goto_next_buffer" }
+         "#;
+ 
++        let mut keys = keymap::default();
++        merge_keys(
++            &mut keys,
++            hashmap! {
++                Mode::Normal => Keymap::new(keymap!({ "Normal mode"
++                    "f" => { ""
++                        "f" => file_picker,
++                        "c" => wclose,
++                    },
++                    "b" => { "buffer"
++                        "b" => buffer_picker,
++                        "n" => goto_next_buffer,
++                    },
++                })),
++            },
++        );
++
+         assert_eq!(
+-            toml::from_str::<Config>(sample_keymaps).unwrap(),
++            Config::load_test(sample_keymaps),
+             Config {
+-                keys: hashmap! {
+-                    Mode::Normal => Keymap::new(keymap!({ "Normal mode"
+-                        "f" => { ""
+-                            "f" => file_picker,
+-                            "c" => wclose,
+-                        },
+-                        "b" => { "buffer"
+-                            "b" => buffer_picker,
+-                            "n" => goto_next_buffer,
+-                        },
+-                    })),
+-                },
++                keys,
+                 ..Default::default()
+             }
+         );
+@@ -221,7 +227,7 @@ mod tests {
+             c = ":buffer-close" 
+         "#;
+ 
+-        let config = toml::from_str::<Config>(sample_keymaps).unwrap();
++        let config = Config::load_test(sample_keymaps);
+ 
+         let tree = config.keys.get(&Mode::Normal).unwrap().root();
+ 
+diff --git a/helix-term/src/keymap.rs b/helix-term/src/keymap.rs
+index d4eb41176de6..8b4247f03211 100644
+--- a/helix-term/src/keymap.rs
++++ b/helix-term/src/keymap.rs
+@@ -197,14 +197,14 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+     where
+         M: serde::de::MapAccess<'de>,
+     {
+-        let mut label = "";
++        let mut label = String::from("");
+         let mut command = None;
+         let mut mapping = HashMap::new();
+         let mut order = Vec::new();
+ 
+-        while let Some(key) = map.next_key::<&str>()? {
+-            match key {
+-                "label" => label = map.next_value::<&str>()?,
++        while let Some(key) = map.next_key::<String>()? {
++            match &key as &str {
++                "label" => label = map.next_value::<String>()?,
+                 "command" => command = Some(map.next_value::<MappableCommand>()?),
+                 _ => {
+                     let key_event = key.parse::<KeyEvent>().map_err(serde::de::Error::custom)?;
+@@ -216,7 +216,7 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+         }
+ 
+         match command {
+-            None => Ok(KeyTrie::Node(KeyTrieNode::new(label, mapping, order))),
++            None => Ok(KeyTrie::Node(KeyTrieNode::new(label.as_str(), mapping, order))),
+             Some(_command) if !order.is_empty() => {
+                 Err(serde::de::Error::custom("ambiguous mapping: 'command' is only valid with 'label', but I found other keys"))
+             }
+
+From e652d01e0c4b5d1a0f2d784711d2631a914994cb Mon Sep 17 00:00:00 2001
+From: Matthew Cheely <matt_cheely@fastmail.com>
+Date: Sun, 22 Oct 2023 13:16:40 +1300
+Subject: [PATCH 09/15] Fix build after latest rebase
+
+---
+ helix-term/src/keymap.rs | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/helix-term/src/keymap.rs b/helix-term/src/keymap.rs
+index 8b4247f03211..f4c1b9e7e8dd 100644
+--- a/helix-term/src/keymap.rs
++++ b/helix-term/src/keymap.rs
+@@ -224,13 +224,13 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+                 Err(serde::de::Error::custom("custom labels are only available for typable commands (the ones starting with ':')"))
+             }
+             Some(MappableCommand::Typable { name, args, .. }) if !label.is_empty() => {
+-                Ok(KeyTrie::Leaf(MappableCommand::Typable {
++                Ok(KeyTrie::MappableCommand(MappableCommand::Typable {
+                     name,
+                     args,
+                     doc: label.to_string(),
+                 }))
+             }
+-            Some(command) => Ok(KeyTrie::Leaf(command)),
++            Some(command) => Ok(KeyTrie::MappableCommand(command)),
+         }
+     }
+ }
+
+From 029f7b441464aa3335c48a53d90ca73aee20e458 Mon Sep 17 00:00:00 2001
+From: Vulpesx <potaytochipgamer@gmail.com>
+Date: Thu, 6 Jun 2024 11:58:19 +1000
+Subject: [PATCH 10/15] fix: tests after merging master
+
+---
+ helix-term/src/config.rs | 15 +++++++++------
+ 1 file changed, 9 insertions(+), 6 deletions(-)
+
+diff --git a/helix-term/src/config.rs b/helix-term/src/config.rs
+index 0363311c4d5a..1cec5c139741 100644
+--- a/helix-term/src/config.rs
++++ b/helix-term/src/config.rs
+@@ -177,7 +177,6 @@ mod tests {
+     #[test]
+     fn parsing_menus() {
+         use crate::keymap;
+-        use crate::keymap::Keymap;
+         use helix_core::hashmap;
+         use helix_view::document::Mode;
+ 
+@@ -191,7 +190,7 @@ mod tests {
+         merge_keys(
+             &mut keys,
+             hashmap! {
+-                Mode::Normal => Keymap::new(keymap!({ "Normal mode"
++                Mode::Normal => keymap!({ "Normal mode"
+                     "f" => { ""
+                         "f" => file_picker,
+                         "c" => wclose,
+@@ -200,7 +199,7 @@ mod tests {
+                         "b" => buffer_picker,
+                         "n" => goto_next_buffer,
+                     },
+-                })),
++                }),
+             },
+         );
+ 
+@@ -229,19 +228,23 @@ mod tests {
+ 
+         let config = Config::load_test(sample_keymaps);
+ 
+-        let tree = config.keys.get(&Mode::Normal).unwrap().root();
++        let tree = config.keys.get(&Mode::Normal).unwrap();
+ 
+         if let keymap::KeyTrie::Node(node) = tree {
+             let open_node = node.get(&KeyEvent::from_str("o").unwrap()).unwrap();
+ 
+-            if let keymap::KeyTrie::Leaf(MappableCommand::Typable { doc, .. }) = open_node {
++            if let keymap::KeyTrie::MappableCommand(MappableCommand::Typable { doc, .. }) =
++                open_node
++            {
+                 assert_eq!(doc, "Edit Config");
+             } else {
+                 panic!("Edit Config did not parse to typable command");
+             }
+ 
+             let close_node = node.get(&KeyEvent::from_str("c").unwrap()).unwrap();
+-            if let keymap::KeyTrie::Leaf(MappableCommand::Typable { doc, .. }) = close_node {
++            if let keymap::KeyTrie::MappableCommand(MappableCommand::Typable { doc, .. }) =
++                close_node
++            {
+                 assert_eq!(doc, ":buffer-close []");
+             } else {
+                 panic!(":buffer-close command did not parse to typable command");
+
+From 6764c3374c5716a8952b8759317dfb9403f2edf9 Mon Sep 17 00:00:00 2001
+From: Vulpesx <potaytochipgamer@gmail.com>
+Date: Thu, 6 Jun 2024 15:17:35 +1000
+Subject: [PATCH 11/15] feat: labels for sequences
+
+---
+ helix-term/src/config.rs | 28 ++++++++++++
+ helix-term/src/keymap.rs | 93 +++++++++++++++++++++++++++++++---------
+ 2 files changed, 100 insertions(+), 21 deletions(-)
+
+diff --git a/helix-term/src/config.rs b/helix-term/src/config.rs
+index 1cec5c139741..f9d6966d6ef9 100644
+--- a/helix-term/src/config.rs
++++ b/helix-term/src/config.rs
+@@ -224,6 +224,8 @@ mod tests {
+             [keys.normal]
+             o = { label = "Edit Config", command = ":open ~/.config" }
+             c = ":buffer-close" 
++            h = ["vsplit", "normal_mode", "swap_view_left"]
++            j = {command = ["hsplit", "normal_mode", {}], label = "split down"}
+         "#;
+ 
+         let config = Config::load_test(sample_keymaps);
+@@ -249,6 +251,32 @@ mod tests {
+             } else {
+                 panic!(":buffer-close command did not parse to typable command");
+             }
++
++            let split_left = node.get(&KeyEvent::from_str("h").unwrap()).unwrap();
++            if let keymap::KeyTrie::Sequence(label, cmds) = split_left {
++                assert_eq!(label, KeyTrie::DEFAULT_SEQUENCE_LABEL);
++                assert_eq!(
++                    *cmds,
++                    vec![
++                        MappableCommand::vsplit,
++                        MappableCommand::normal_mode,
++                        MappableCommand::swap_view_left
++                    ]
++                );
++            }
++
++            let split_down = node.get(&KeyEvent::from_str("j").unwrap()).unwrap();
++            if let keymap::KeyTrie::Sequence(label, cmds) = split_down {
++                assert_eq!(label, "split down");
++                assert_eq!(
++                    *cmds,
++                    vec![
++                        MappableCommand::hsplit,
++                        MappableCommand::normal_mode,
++                        MappableCommand::swap_view_down
++                    ]
++                );
++            }
+         } else {
+             panic!("Config did not parse to trie");
+         }
+diff --git a/helix-term/src/keymap.rs b/helix-term/src/keymap.rs
+index f4c1b9e7e8dd..77a8bc58695b 100644
+--- a/helix-term/src/keymap.rs
++++ b/helix-term/src/keymap.rs
+@@ -12,6 +12,7 @@ use std::{
+     borrow::Cow,
+     collections::{BTreeSet, HashMap},
+     ops::{Deref, DerefMut},
++    str::FromStr,
+     sync::Arc,
+ };
+ 
+@@ -83,7 +84,7 @@ impl KeyTrieNode {
+                     cmd.doc()
+                 }
+                 KeyTrie::Node(n) => &n.name,
+-                KeyTrie::Sequence(_) => "[Multiple commands]",
++                KeyTrie::Sequence(..) => KeyTrie::DEFAULT_SEQUENCE_LABEL,
+             };
+             match body.iter().position(|(_, d)| d == &desc) {
+                 Some(pos) => {
+@@ -133,10 +134,18 @@ impl DerefMut for KeyTrieNode {
+ #[derive(Debug, Clone, PartialEq)]
+ pub enum KeyTrie {
+     MappableCommand(MappableCommand),
+-    Sequence(Vec<MappableCommand>),
++    Sequence(String, Vec<MappableCommand>),
+     Node(KeyTrieNode),
+ }
+ 
++impl KeyTrie {
++    pub const DEFAULT_SEQUENCE_LABEL: &'static str = "[Multiple commands]";
++
++    pub fn sequence(commands: Vec<MappableCommand>) -> Self {
++        Self::Sequence(Self::DEFAULT_SEQUENCE_LABEL.to_string(), commands)
++    }
++}
++
+ impl<'de> Deserialize<'de> for KeyTrie {
+     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+     where
+@@ -190,7 +199,10 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+             ));
+         }
+ 
+-        Ok(KeyTrie::Sequence(commands))
++        Ok(KeyTrie::Sequence(
++            KeyTrie::DEFAULT_SEQUENCE_LABEL.to_string(),
++            commands,
++        ))
+     }
+ 
+     fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+@@ -205,7 +217,35 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+         while let Some(key) = map.next_key::<String>()? {
+             match &key as &str {
+                 "label" => label = map.next_value::<String>()?,
+-                "command" => command = Some(map.next_value::<MappableCommand>()?),
++                "command" => {
++                    command = Some(match map.next_value::<toml::Value>()? {
++                        toml::Value::String(s) => {
++                            vec![MappableCommand::from_str(&s).map_err(serde::de::Error::custom)?]
++                        }
++                        toml::Value::Array(arr) => {
++                            let mut vec = Vec::with_capacity(arr.len());
++                            for value in arr {
++                                let toml::Value::String(s) = value else {
++                                    return Err(serde::de::Error::invalid_type(
++                                        serde::de::Unexpected::Other(value.type_str()),
++                                        &"string",
++                                    ));
++                                };
++                                vec.push(
++                                    MappableCommand::from_str(&s)
++                                        .map_err(serde::de::Error::custom)?,
++                                );
++                            }
++                            vec
++                        }
++                        value => {
++                            return Err(serde::de::Error::invalid_type(
++                                serde::de::Unexpected::Other(value.type_str()),
++                                &"string or array",
++                            ))
++                        }
++                    });
++                }
+                 _ => {
+                     let key_event = key.parse::<KeyEvent>().map_err(serde::de::Error::custom)?;
+                     let key_trie = map.next_value::<KeyTrie>()?;
+@@ -220,17 +260,28 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+             Some(_command) if !order.is_empty() => {
+                 Err(serde::de::Error::custom("ambiguous mapping: 'command' is only valid with 'label', but I found other keys"))
+             }
+-            Some(MappableCommand::Static { .. }) if !label.is_empty() => {
+-                Err(serde::de::Error::custom("custom labels are only available for typable commands (the ones starting with ':')"))
+-            }
+-            Some(MappableCommand::Typable { name, args, .. }) if !label.is_empty() => {
+-                Ok(KeyTrie::MappableCommand(MappableCommand::Typable {
+-                    name,
+-                    args,
+-                    doc: label.to_string(),
+-                }))
++            Some(mut commands) if commands.len() == 1 => match commands.pop() {
++                None => Err(serde::de::Error::custom("UNREACHABLE!, vec is empty after checking len == 1")),
++                Some(MappableCommand::Static { .. }) if !label.is_empty() => {
++                    Err(serde::de::Error::custom("custom labels are only available for typable commands (the ones starting with ':')"))
++                }
++                Some(MappableCommand::Typable { name, args, .. }) if !label.is_empty() => {
++                    Ok(KeyTrie::MappableCommand(MappableCommand::Typable {
++                        name,
++                        args,
++                        doc: label,
++                    }))
++                }
++                Some(command) => Ok(KeyTrie::MappableCommand(command)),
+             }
+-            Some(command) => Ok(KeyTrie::MappableCommand(command)),
++            Some(commands) => {
++                let label = if label.is_empty() {
++                    KeyTrie::DEFAULT_SEQUENCE_LABEL.to_string()
++                } else {
++                    label
++                };
++                Ok(KeyTrie::Sequence(label, commands))
++            },
+         }
+     }
+ }
+@@ -254,7 +305,7 @@ impl KeyTrie {
+                         keys.pop();
+                     }
+                 }
+-                KeyTrie::Sequence(_) => {}
++                KeyTrie::Sequence(..) => {}
+             };
+         }
+ 
+@@ -266,14 +317,14 @@ impl KeyTrie {
+     pub fn node(&self) -> Option<&KeyTrieNode> {
+         match *self {
+             KeyTrie::Node(ref node) => Some(node),
+-            KeyTrie::MappableCommand(_) | KeyTrie::Sequence(_) => None,
++            KeyTrie::MappableCommand(_) | KeyTrie::Sequence(..) => None,
+         }
+     }
+ 
+     pub fn node_mut(&mut self) -> Option<&mut KeyTrieNode> {
+         match *self {
+             KeyTrie::Node(ref mut node) => Some(node),
+-            KeyTrie::MappableCommand(_) | KeyTrie::Sequence(_) => None,
++            KeyTrie::MappableCommand(_) | KeyTrie::Sequence(..) => None,
+         }
+     }
+ 
+@@ -290,7 +341,7 @@ impl KeyTrie {
+             trie = match trie {
+                 KeyTrie::Node(map) => map.get(key),
+                 // leaf encountered while keys left to process
+-                KeyTrie::MappableCommand(_) | KeyTrie::Sequence(_) => None,
++                KeyTrie::MappableCommand(_) | KeyTrie::Sequence(..) => None,
+             }?
+         }
+         Some(trie)
+@@ -380,7 +431,7 @@ impl Keymaps {
+             Some(KeyTrie::MappableCommand(ref cmd)) => {
+                 return KeymapResult::Matched(cmd.clone());
+             }
+-            Some(KeyTrie::Sequence(ref cmds)) => {
++            Some(KeyTrie::Sequence(_, ref cmds)) => {
+                 return KeymapResult::MatchedSequence(cmds.clone());
+             }
+             None => return KeymapResult::NotFound,
+@@ -400,7 +451,7 @@ impl Keymaps {
+                 self.state.clear();
+                 KeymapResult::Matched(cmd.clone())
+             }
+-            Some(KeyTrie::Sequence(cmds)) => {
++            Some(KeyTrie::Sequence(_, cmds)) => {
+                 self.state.clear();
+                 KeymapResult::MatchedSequence(cmds.clone())
+             }
+@@ -625,7 +676,7 @@ mod tests {
+         let expectation = KeyTrie::Node(KeyTrieNode::new(
+             "",
+             hashmap! {
+-                key => KeyTrie::Sequence(vec!{
++                key => KeyTrie::sequence(vec!{
+                     MappableCommand::select_all,
+                     MappableCommand::Typable {
+                         name: "pipe".to_string(),
+
+From bb8a44cec0cfcff0cd4eba3b3c4157b65bddcc86 Mon Sep 17 00:00:00 2001
+From: Vulpesx <potaytochipgamer@gmail.com>
+Date: Thu, 6 Jun 2024 15:48:56 +1000
+Subject: [PATCH 12/15] fix: forgor to tell helix to display sequence labels
+
+---
+ helix-term/src/keymap.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/helix-term/src/keymap.rs b/helix-term/src/keymap.rs
+index 77a8bc58695b..f47160e73b2f 100644
+--- a/helix-term/src/keymap.rs
++++ b/helix-term/src/keymap.rs
+@@ -84,7 +84,7 @@ impl KeyTrieNode {
+                     cmd.doc()
+                 }
+                 KeyTrie::Node(n) => &n.name,
+-                KeyTrie::Sequence(..) => KeyTrie::DEFAULT_SEQUENCE_LABEL,
++                KeyTrie::Sequence(l, ..) => l,
+             };
+             match body.iter().position(|(_, d)| d == &desc) {
+                 Some(pos) => {
+
+From e625945398dbbae475f13a2375a0a6b427a4ff16 Mon Sep 17 00:00:00 2001
+From: Nylme <nylme@protonmail.com>
+Date: Tue, 19 Nov 2024 08:09:21 +1100
+Subject: [PATCH 13/15] Fixed deserializing macro labels/names from .toml
+ keymap
+
+---
+ helix-term/src/keymap.rs | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/helix-term/src/keymap.rs b/helix-term/src/keymap.rs
+index f47160e73b2f..a01a05f866bb 100644
+--- a/helix-term/src/keymap.rs
++++ b/helix-term/src/keymap.rs
+@@ -272,6 +272,15 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
+                         doc: label,
+                     }))
+                 }
++
++                // To label/name macro commands from config
++                Some(MappableCommand::Macro { keys, .. }) if !label.is_empty() => {
++                    Ok(KeyTrie::MappableCommand(MappableCommand::Macro {
++                        keys,
++                        name: label
++                    }))
++                }
++
+                 Some(command) => Ok(KeyTrie::MappableCommand(command)),
+             }
+             Some(commands) => {
+
+From af83072ebf66a04f8033cbbfcb7ca0a454c8c6f2 Mon Sep 17 00:00:00 2001
+From: Nylme <nylme@protonmail.com>
+Date: Tue, 19 Nov 2024 22:29:26 +1100
+Subject: [PATCH 14/15] parsing_typeable_commands: fixed test
+
+---
+ helix-term/src/config.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/helix-term/src/config.rs b/helix-term/src/config.rs
+index f9d6966d6ef9..abc6784486cb 100644
+--- a/helix-term/src/config.rs
++++ b/helix-term/src/config.rs
+@@ -225,7 +225,7 @@ mod tests {
+             o = { label = "Edit Config", command = ":open ~/.config" }
+             c = ":buffer-close" 
+             h = ["vsplit", "normal_mode", "swap_view_left"]
+-            j = {command = ["hsplit", "normal_mode", {}], label = "split down"}
++            j = {command = ["hsplit", "normal_mode", "swap_view_down"], label = "split down"}
+         "#;
+ 
+         let config = Config::load_test(sample_keymaps);
+
+From 8e7e1283a572379bef40e5b8deb3ecef4e7962ac Mon Sep 17 00:00:00 2001
+From: Nylme <nylme@protonmail.com>
+Date: Tue, 19 Nov 2024 22:32:20 +1100
+Subject: [PATCH 15/15] parsing_typeable_commands: added test for macro command
+ labels
+
+---
+ helix-term/src/config.rs | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/helix-term/src/config.rs b/helix-term/src/config.rs
+index abc6784486cb..4c2340e91226 100644
+--- a/helix-term/src/config.rs
++++ b/helix-term/src/config.rs
+@@ -226,6 +226,7 @@ mod tests {
+             c = ":buffer-close" 
+             h = ["vsplit", "normal_mode", "swap_view_left"]
+             j = {command = ["hsplit", "normal_mode", "swap_view_down"], label = "split down"}
++            n = { label = "Delete word", command = "@wd" }
+         "#;
+ 
+         let config = Config::load_test(sample_keymaps);
+@@ -277,6 +278,20 @@ mod tests {
+                     ]
+                 );
+             }
++
++            let macro_keys = node.get(&KeyEvent::from_str("n").unwrap()).unwrap();
++            if let keymap::KeyTrie::MappableCommand(MappableCommand::Macro { name, keys }) =
++                macro_keys
++            {
++                assert_eq!(name, "Delete word");
++                assert_eq!(
++                    keys,
++                    &vec![
++                        KeyEvent::from_str("w").unwrap(),
++                        KeyEvent::from_str("d").unwrap()
++                    ]
++                );
++            }
+         } else {
+             panic!("Config did not parse to trie");
+         }
+

--- a/patches/helix/3958-labels-for-config-menus.patch.license
+++ b/patches/helix/3958-labels-for-config-menus.patch.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2025 Matthew Cheely <matt_cheely@fastmail.com>
+SPDX-FileCopyrightText: 2025 Nylme <nylme@protonmail.com>
+SPDX-FileCopyrightText: 2025 Vulpesx <potaytochipgamer@gmail.com>
+
+SPDX-License-Identifier: MPL-2.0


### PR DESCRIPTION
We've been using helix editor since the start but up until now it has only been in configuration.nix rather than getting config through home-manager. The config I've added here is a compilation of a couple of pieces of work...

- My currently-set options
- Some past config I had for some nice keybindings

Additionally, the keybinding piece also needs a long-awaited helix PR - we can just go ahead and patch that in

---

I've kept helix in configuration.nix too as I want to make sure that we still have a nice editor for, say, editing files as root/etc. Probably it should go in some file in "common" instead but that can be a followup