### PR TITLE
ci: make nixos build run only once

### DIFF
--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -13,6 +13,10 @@ on:
 
   workflow_dispatch:
 
+concurrency: # Since as this check is expensive, it's a bad idea to keep running it when we push new commits...
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This check is quite expensive, so if we push new commits to a branch it is worth cancelling anything that is already running