### PR TITLE
feat(homes): add ssh-agent

### DIFF
--- a/homes/default.nix
+++ b/homes/default.nix
@@ -35,6 +35,7 @@ in {
       ./development
       ./gaming
       (import ./niri { inherit (config.inputs) niri walker; })
+      ./remote
     ];
     args = {
       system = "x86_64-linux";

--- a/homes/remote/default.nix
+++ b/homes/remote/default.nix
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  imports = [
+    ./ssh.nix
+  ];
+}

--- a/homes/remote/ssh.nix
+++ b/homes/remote/ssh.nix
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  services.ssh-agent.enable = true;
+  home.sessionVariables.SSH_AUTH_SOCK = "/run/user/$UID/ssh-agent";
+}


### PR DESCRIPTION
Without ssh-agent we are unable to ssh-add -K to import ssh keys from our yubikeys