### PR TITLE
feat(homes/development): Add VSCode

### DIFF
--- a/homes/development/default.nix
+++ b/homes/development/default.nix
@@ -5,6 +5,7 @@
 {
   imports = [
     ./direnv.nix
+    ./editor.nix
     ./helix.nix
     ./hoppscotch.nix
     ./simplified-utilities.nix

--- a/homes/development/editor.nix
+++ b/homes/development/editor.nix
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  programs.vscode.enable = true;
+}


### PR DESCRIPTION
Currently helix doesn't offer a good way to collaborate with someone so we install VSCode to account for this possibility.