### PR TITLE
feat(gpg): Enable GPG for signing

### DIFF
--- a/homes/development/default.nix
+++ b/homes/development/default.nix
@@ -5,6 +5,7 @@
 {
   imports = [
     ./direnv.nix
+    ./gpg.nix
     ./helix.nix
     ./hoppscotch.nix
     ./simplified-utilities.nix

--- a/homes/development/gpg.nix
+++ b/homes/development/gpg.nix
@@ -1,7 +1,18 @@
 # SPDX-FileCopyrightText: 2025 FreshlyBakedCake
 #
 # SPDX-License-Identifier: MIT
+{ pkgs, ... }: {
+  programs.gpg = {
+    enable = true;
+    scdaemonSettings = {
+      reader-port = "Yubico Yubi";
+      disable-ccid = true;
+    };
+  };
 
-{
-  programs.gpg.enable = true;
+  services.gpg-agent = {
+    enable = true;
+    enableScDaemon = true;
+    pinentry.package = pkgs.pinentry-gnome3;
+  };
 }

--- a/homes/development/gpg.nix
+++ b/homes/development/gpg.nix
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  programs.gpg.enable = true;
+}

--- a/systems/common/default.nix
+++ b/systems/common/default.nix
@@ -13,6 +13,7 @@
     ./nilla-nix.nix
     ./nixos.nix
     ./packetmix.nix
+    ./smartcard.nix
     ./sudo.nix
     ./sysctl.nix
   ];

--- a/systems/common/smartcard.nix
+++ b/systems/common/smartcard.nix
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  services.pcscd.enable = true;
+}


### PR DESCRIPTION
We can now use GPG to sign commits. This also enabled us to do so with yubikeys
