### PR TITLE
feat(homes/coded): Add appimage-run

### DIFF
--- a/homes/coded/appimage.nix
+++ b/homes/coded/appimage.nix
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, ... }:
+{
+  home.packages = [ pkgs.appimage-run ];
+}

--- a/homes/coded/default.nix
+++ b/homes/coded/default.nix
@@ -7,6 +7,7 @@
 # depends on development flavor
 {
   imports = [
+    ./appimage.nix
     ./bitwarden.nix
     ./calendar.nix
     ./catppuccin.nix


### PR DESCRIPTION
I've added this so I can use Cider-2 using an AppImage as it is unfree software