### PR TITLE
ci: ban evaluation warnings

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+name: Evaluate NixOS systems and Homes
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  workflow_dispatch:
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Lix
+        uses: samueldr/lix-gha-installer-action@8dc19fbd6451fa106a68ecb2dafeeeb90dff3a29
+        with:
+          extra_nix_config: "experimental-features = nix-command"
+
+      - run: cd $GITHUB_WORKSPACE
+
+      - name: Evaluate all systems
+        run: |
+          eval_out=$(nix-instantiate ./nilla.nix -A packages.allNixOSSystems.result.x86_64-linux --add-root ./system-root 2>&1 | tee /dev/stderr)
+          eval_warns=$(echo "$eval_out" | grep "evaluation warning:" || true)
+
+          if [ -n "$eval_warns" ]; then
+            echo "There were some warnings while evaluating your systems:"
+            echo "$eval_warns"
+            echo "Please fix these and squash into your existing commits"
+            exit 1
+          fi
+
+      - name: Evaluate all homes
+        run: |
+          eval_out=$(nix-instantiate ./nilla.nix -A packages.allNixOSSystems.result.x86_64-linux --add-root ./home-root 2>&1 | tee /dev/stderr)
+          eval_warns=$(echo "$eval_out" | grep "evaluation warning:" || true)
+
+          if [ -n "$eval_warns" ]; then
+            echo "There were some warnings while evaluating your homes:"
+            echo "$eval_warns"
+            echo "Please fix these and squash into your existing commits"
+            exit 1
+          fi

--- a/homes/catppuccin/catppuccin.nix
+++ b/homes/catppuccin/catppuccin.nix
@@ -5,7 +5,7 @@
 { catppuccin }:
 { project, lib, ... }:
 {
-  imports = [ catppuccin.result.homeManagerModules.catppuccin ];
+  imports = [ catppuccin.result.homeModules.catppuccin ];
   config.catppuccin.enable = true;
   config.catppuccin.gtk.enable = true;
 }

--- a/homes/niri/niri.nix
+++ b/homes/niri/niri.nix
@@ -43,7 +43,7 @@
 
         input.touchpad.natural-scroll = true;
 
-        input.warp-mouse-to-focus = true;
+        input.warp-mouse-to-focus.enable = true;
         input.focus-follows-mouse = {
           enable = true;
           max-scroll-amount = "0%";

--- a/systems/teal/hardware-configuration.nix
+++ b/systems/teal/hardware-configuration.nix
@@ -30,6 +30,9 @@
   };
 
   boot.swraid.enable = true;
+  boot.swraid.mdadmConf = ''
+    PROGRAM=true
+  ''; # Disable reporting for this system
 
   clicks.storage.impermanence = {
     enable = true;


### PR DESCRIPTION
We will get evaluation warnings in two circumstances:
- We write some code that is doing something wrong
- Something gets deprecated in a routine npins bump

In either case we probably don't want to merge the breaking change - rather it would be nice to get notified so we can fix it