### PR TITLE
fix(ssh-agent): add SSH_ASKPASS

### DIFF
--- a/homes/remote/ssh.nix
+++ b/homes/remote/ssh.nix
@@ -2,7 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
+{ pkgs, ... }:
 {
   services.ssh-agent.enable = true;
+  systemd.user.services.ssh-agent.Service.Environment =
+    "SSH_ASKPASS=${pkgs.kdePackages.ksshaskpass}/bin/ksshaskpass";
   home.sessionVariables.SSH_AUTH_SOCK = "/run/user/$UID/ssh-agent";
 }


### PR DESCRIPTION
Previously we enabled the ssh-agent for users but didn't add any askpass command. This meant that if you were using a key that needed a pin it would immediately fail.

We can fix that by providing an SSH_ASKPASS environment variable to the service as it is started. Setting this for shells (e.g. via NixOS' programs.ssh.enableAskPassword) doesn't work as the agent never gets access to the set variable