### PR TITLE
feat(homes/dev/collab): Make vim_mode an option

### DIFF
--- a/homes/development/collaboration.nix
+++ b/homes/development/collaboration.nix
@@ -2,9 +2,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ pkgs, ... }:
+{ config, lib, ... }:
 {
-  programs.zed-editor = {
+  options.zed.vim_mode = lib.mkOption {
+    default = true;
+    type = lib.types.bool;
+  };
+
+  config.programs.zed-editor = {
     enable = true;
     extensions = [
       "catppuccin"
@@ -14,7 +19,7 @@
     userSettings = {
       git.git_gutter = "hide";
       minimap.show = "auto";
-      vim_mode = true;
+      vim_mode = config.zed.vim_mode;
     };
   };
 }


### PR DESCRIPTION
Some users may prefer to not have vim keybinds, this creates an option which is defaulted to true as current users are more inclined to use vim mode.