### PR TITLE
feat(niri): Add dynamic casting binds

### DIFF
--- a/homes/niri/niri.nix
+++ b/homes/niri/niri.nix
@@ -109,6 +109,11 @@
             "${mod}+D".action.spawn = "${config.programs.walker.package}/bin/walker";
 
             "${mod}+Shift+Slash".action.show-hotkey-overlay = [ ];
+
+            "${mod}+V".action.set-dynamic-cast-monitor = [ ];
+            "${mod}+W".action.set-dynamic-cast-window = [ ];
+            "${mod}+Shift+V".action.clear-dynamic-cast-target = [ ];
+            "${mod}+Shift+W".action.clear-dynamic-cast-target = [ ];
           }
           //
             # Workspace Keybinds


### PR DESCRIPTION
Niri has a rather neat "dynamic casting" feature where you can select a window/screen to be cast to a dynamic target (think like changing the window you are screen-sharing over Discord from your keybindings...).

I'd like to use this when screen recording in OBS, but it's unwieldy without any bindings. Therefore, let's add W and V (theoretically nmemonically for Window and Video) to set ... Windows and full monitor Videos to the dynamic target - these should be OK since as we don't use them for any other bindings and they make some sense.