### PR TITLE
feat(systems/personal): Add espanso

### DIFF
--- a/systems/personal/default.nix
+++ b/systems/personal/default.nix
@@ -6,6 +6,7 @@
   imports = [
     ./bluetooth.nix
     ./configuration.nix
+    ./espanso.nix
     ./homes.nix
   ];
 }

--- a/systems/personal/espanso.nix
+++ b/systems/personal/espanso.nix
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, config, ... }:
+{
+  services.espanso = {
+    enable = true;
+    package = if config.services.xserver.enable then pkgs.espanso else pkgs.espanso-wayland;
+  };
+}


### PR DESCRIPTION
Espanso is a live text modifier/expander that can be used for various purposes from spelling correction to inserting the time