### PR TITLE
Add oxidize ingredient

### DIFF
--- a/systems/common/fonts.nix
+++ b/systems/common/fonts.nix
@@ -10,6 +10,7 @@
     pkgs.corefonts
     pkgs.fira-code
     pkgs.fira-sans
+    pkgs.nerd-fonts.symbols-only
   ];
 
   fonts.enableDefaultPackages = true;

--- a/systems/oxidize/default.nix
+++ b/systems/oxidize/default.nix
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ lib, config, ... }:
+{
+  options.oxidize.unstable = lib.mkEnableOption "Enable unstable/in development rust drop in replacements";
+  imports = [
+    ./eza.nix
+  ] ++ (if config.oxidize.unstable then [ ./uutils.nix ] else [ ]);
+}

--- a/systems/oxidize/eza.nix
+++ b/systems/oxidize/eza.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+{ pkgs, ... }:
+{
+  environment.systemPackages = [
+    (pkgs.eza.override {
+      gitSupport = false;
+      exaAlias = false;
+    })
+  ];
+}

--- a/systems/oxidize/uutils.nix
+++ b/systems/oxidize/uutils.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, ... }:
+{
+  environment.systemPackages = [
+    pkgs.uutils-coreutils-noprefix
+    pkgs.uutils-findutils
+    pkgs.uutils-diffutils
+  ];
+}


### PR DESCRIPTION
The purpose of this ingredient is to add rust-y alternatives to built in commands (eg: eza for ls)