### PR TITLE
some espanso fixes

### DIFF
--- a/systems/default.nix
+++ b/systems/default.nix
@@ -11,6 +11,7 @@ in
     pkgs = nixpkgs.x86_64-linux;
     modules = [
       ./common
+      ./espanso
       ./javelin
       ./minion
       ./niri
@@ -27,6 +28,7 @@ in
     pkgs = nixpkgs.x86_64-linux;
     modules = [
       ./common
+      ./espanso
       ./gaming
       ./javelin
       ./minion
@@ -44,6 +46,7 @@ in
     pkgs = nixpkgs.x86_64-linux;
     modules = [
       ./common
+      ./espanso
       ./gaming
       ./niri
       ./ocicat

--- a/systems/espanso/default.nix
+++ b/systems/espanso/default.nix
@@ -5,5 +5,6 @@
 {
   imports = [
     ./espanso.nix
+    ./nixpkgs-328890--espanso-capdacoverride
   ];
 }

--- a/systems/espanso/default.nix
+++ b/systems/espanso/default.nix
@@ -4,8 +4,6 @@
 
 {
   imports = [
-    ./bluetooth.nix
-    ./configuration.nix
-    ./homes.nix
+    ./espanso.nix
   ];
 }

--- a/systems/espanso/espanso.nix
+++ b/systems/espanso/espanso.nix
@@ -8,4 +8,6 @@
     enable = true;
     package = if config.services.xserver.enable then pkgs.espanso else pkgs.espanso-wayland;
   };
+
+  programs.espanso.capdacoverride.enable = !config.services.xserver.enable;
 }

--- a/systems/espanso/nixpkgs-328890--espanso-capdacoverride/default.nix
+++ b/systems/espanso/nixpkgs-328890--espanso-capdacoverride/default.nix
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 Eelco Dolstra and the Nixpkgs/NixOS contributors
+#
+# SPDX-License-Identifier: MIT
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.espanso.capdacoverride;
+in
+{
+  meta = {
+    maintainers = with lib.maintainers; [ pitkling ];
+  };
+
+  options = {
+    programs.espanso.capdacoverride = {
+      enable = (lib.mkEnableOption "espanso-wayland overlay with DAC_OVERRIDE capability") // {
+        description = ''
+          Creates an espanso binary with the DAC_OVERRIDE capability (via `security.wrappers`) and overlays `pkgs.espanso-wayland` such that self-forks call the capability-enabled binary.
+          Required for `pkgs.espanso-wayland` to work correctly if not run with root privileges.
+        '';
+      };
+
+      package = lib.mkOption {
+        type = lib.types.package // {
+          check = package: lib.types.package.check package && (builtins.elem "wayland" package.buildFeatures);
+          description =
+            lib.types.package.description
+            + " for espanso with wayland support (`package.builtFeatures` must contain `\"wayland\"`)";
+        };
+        default = pkgs._espanso-wayland-orig;
+        defaultText = "pkgs.espanso-wayland (before applying the overlay)";
+        description = "The espanso-wayland package used as the base to generate the capability-enabled package.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    nixpkgs.overlays = [
+      (final: prev: {
+        _espanso-wayland-orig = prev.espanso-wayland;
+        espanso-wayland = pkgs.callPackage ./espanso-capdacoverride.nix {
+          capDacOverrideWrapperDir = "${config.security.wrapperDir}";
+          espanso = cfg.package;
+        };
+      })
+    ];
+
+    security.wrappers."espanso-wayland" = {
+      source = lib.getExe pkgs.espanso-wayland;
+      capabilities = "cap_dac_override+p";
+      owner = "root";
+      group = "root";
+    };
+  };
+}

--- a/systems/espanso/nixpkgs-328890--espanso-capdacoverride/espanso-capdacoverride.nix
+++ b/systems/espanso/nixpkgs-328890--espanso-capdacoverride/espanso-capdacoverride.nix
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 Eelco Dolstra and the Nixpkgs/NixOS contributors
+#
+# SPDX-License-Identifier: MIT
+
+{
+  autoPatchelfHook,
+  capDacOverrideWrapperDir,
+  espanso,
+  patchelfUnstable, # have to use patchelfUnstable to support --rename-dynamic-symbols
+  stdenv,
+}:
+let
+  inherit (espanso) version;
+  pname = "${espanso.pname}-capdacoverride";
+
+  wrapperLibName = "wrapper-lib.so";
+
+  # On Wayland, Espanso requires the DAC_OVERRIDE capability. One can create a wrapper binary with this
+  # capability using the `config.security.wrappers.<name>` framework. However, this is not enough: the
+  # capability is required by a worker process of Espanso created by forking `/proc/self/exe`, which points
+  # to the executable **without** the DAC_OVERRIDE capability. Thus, we inject a wrapper library into Espanso
+  # that redirects requests to `/proc/self/exe` to the binary with the proper capabilities.
+  wrapperLib = stdenv.mkDerivation {
+    name = "${pname}-${version}-wrapper-lib";
+
+    dontUnpack = true;
+
+    postPatch = ''
+      substitute ${./wrapper-lib.c} lib.c --subst-var-by to "${capDacOverrideWrapperDir}/espanso-wayland"
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+      cc -fPIC -shared lib.c -o ${wrapperLibName}
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      install -D -t $out/lib ${wrapperLibName}
+      runHook postInstall
+    '';
+  };
+in
+espanso.overrideAttrs (previousAttrs: {
+  inherit pname;
+
+  buildInputs = previousAttrs.buildInputs ++ [ wrapperLib ];
+
+  nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [
+    autoPatchelfHook
+    patchelfUnstable
+  ];
+
+  postInstall =
+    ''
+      echo readlink readlink_wrapper > readlink_name_map
+      patchelf \
+        --rename-dynamic-symbols readlink_name_map \
+        --add-needed ${wrapperLibName} \
+        "$out/bin/espanso"
+    ''
+    + previousAttrs.postInstall;
+})

--- a/systems/espanso/nixpkgs-328890--espanso-capdacoverride/wrapper-lib.c
+++ b/systems/espanso/nixpkgs-328890--espanso-capdacoverride/wrapper-lib.c
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Eelco Dolstra and the Nixpkgs/NixOS contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char from[] =  "/proc/self/exe";
+static const char to[]   = "@to@";
+
+ssize_t readlink_wrapper(const char *restrict path, char *restrict buf, size_t bufsize) {
+    if (strcmp(path, from) == 0) {
+        printf("readlink_wrapper.c: Resolving readlink call to '%s' to '%s'\n", from, to);
+        size_t to_length = strlen(to);
+        if (to_length > bufsize) {
+            to_length = bufsize;
+        }
+        memcpy(buf, to, to_length);
+        return to_length;
+    } else {
+        return readlink(path, buf, bufsize);
+    }
+}


### PR DESCRIPTION
Espanso does various things that are bad if we don't get permission
- Making a window on first startup
- Requiring configuration or there will be an error window
- Needing some "interesting" capability/permission hacks

Given not everyone will necessarily want this, and that it has quite
high potential to cause trouble, we shouldn't be putting it even in
personal - let's give it its own ingredient

---

I've pulled in some hacks from https://github.com/NixOS/nixpkgs/pull/328890 to correct the
capabilities here. Without it, espanso required setting some permissions
on /dev/uinput and adding the running user to the "input" group, which
is a much worse hack