### PR TITLE
fix: prevent espanso build failure

### DIFF
--- a/homes/coded/default.nix
+++ b/homes/coded/default.nix
@@ -12,7 +12,6 @@
     ./calendar.nix
     ./catppuccin.nix
     ./email.nix
-    ./keyboard.nix
     ./niri.nix
     ./sesh.nix
   ];

--- a/homes/coded/keyboard.nix
+++ b/homes/coded/keyboard.nix
@@ -1,7 +1,0 @@
-# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
-#
-# SPDX-License-Identifier: MIT
-
-{
-  home.keyboard.layout = "us";
-}

--- a/homes/espanso/espanso.nix
+++ b/homes/espanso/espanso.nix
@@ -2,17 +2,24 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ config, ... }:
+{ config, lib, ... }:
 {
-  xdg.configFile."espanso/config/default.yml".text = builtins.toJSON {
-    search_trigger = ":search";
-    show_notifications = false;
-    keyboard_layout = {
-      model = config.home.keyboard.model;
-      layout = config.home.keyboard.layout;
-      variant = config.home.keyboard.variant;
+  xdg.configFile."espanso/config/default.yml".text = builtins.toJSON (
+    {
+      search_trigger = ":search";
+      show_notifications = false;
+    }
+    // (
+      if (config.home.keyboard != null) then
+        {
+          keyboard_layout = {
+            inherit (config.home.keyboard) layout model variant;
 
-      options = builtins.concatStringsSep "," config.home.keyboard.options;
-    };
-  };
+            options = builtins.concatStringsSep "," config.home.keyboard.options;
+          };
+        }
+      else
+        { }
+    )
+  );
 }


### PR DESCRIPTION
When you didn't have a keyboard layout set you would try to set values from a null

We erroneously changed from an inherit here in an attempt to avoid the problem, however the real change is to avoid setting the keyboard options at all if you haven't specified anything.

This is the same as we do in niri