### PR TITLE
feat: add swaync

### DIFF
--- a/homes/niri/default.nix
+++ b/homes/niri/default.nix
@@ -6,5 +6,6 @@
 {
   imports = [
     (import ./niri.nix { inherit niri walker; })
+    ./swaync.nix
   ];
 }

--- a/homes/niri/niri.nix
+++ b/homes/niri/niri.nix
@@ -121,6 +121,13 @@
             "${mod}+W".action.set-dynamic-cast-window = [ ];
             "${mod}+Shift+V".action.clear-dynamic-cast-target = [ ];
             "${mod}+Shift+W".action.clear-dynamic-cast-target = [ ];
+
+            "${mod}+N".action.spawn = [
+              "sh"
+              "-c"
+              "${pkgs.systemd}/bin/systemctl --user start swaync && ${pkgs.swaynotificationcenter}/bin/swaync-client -t"
+            ];
+            # We need to ensure swaync is started, since as it isn't usually until we get a notification
           }
           //
             # Workspace Keybinds

--- a/homes/niri/niri.nix
+++ b/homes/niri/niri.nix
@@ -285,8 +285,29 @@
 
     programs.bash.profileExtra = lib.mkBefore ''
       if [ -z $WAYLAND_DISPLAY ] && [ "$(tty)" = "/dev/tty1" ]; then
-        exec ${pkgs.systemd}/bin/systemd-cat -t niri ${pkgs.dbus}/bin/dbus-run-session ${config.programs.niri.package}/bin/niri --session
+        exec ${config.programs.niri.package}/bin/niri-session -l
       fi
     '';
+
+    systemd.user.services.niri = {
+      Unit = {
+        Description = "A scrollable-tiling Wayland compositor";
+        BindsTo = "graphical-session.target";
+        Wants = [
+          "graphical-session-pre.target"
+          "xdg-desktop-autostart.target"
+        ];
+        After = [
+          "graphical-session-pre.target"
+          "xdg-desktop-autostart.target"
+        ];
+      };
+
+      Service = {
+        Slice = "session.slice";
+        Type = "notify";
+        ExecStart = "${config.programs.niri.package}/bin/niri --session";
+      };
+    };
   };
 }

--- a/homes/niri/swaync.nix
+++ b/homes/niri/swaync.nix
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 FreshyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  services.swaync.enable = true;
+}


### PR DESCRIPTION
previously niri was running directly as `niri --session`, however this
seems to cause some race conditions for some dbus services (e.g. our
notifications daemon starting in a different session to niri, stopping
us from opening it)

we can solve this by tying the graphical start target to niri starting,
and using niri-session to start niri. Without `-l` on `niri-session`
niri appears to freeze - it seems like the `-l` starts another login
shell, I'm not sure why it's necessary (and it doesn't seem to be
necessary when running niri interactively)

---

all this in aid of adding swaync...

swaync is a notification daemon - so finally we can stop Firefox, etc.
from creating its own windows and get notifications from things like
Thunderbird

last iteration we had problems with mako, so we were considering dunst
or swaync - swaync won out for its better (in our humble opinions)
notification center, which is closer to what we want our dashboard
concept to be, its do-not-disturb support, etc. We've added the
dashboard to Mod+N (for "Notifications")

if we ever get another window manager without a notification daemon it
may be worth pulling this out into an ingredient, but for now it's small
enough to live in niri