### PR TITLE
feat: disable espanso notifications

### DIFF
--- a/homes/espanso/espanso.nix
+++ b/homes/espanso/espanso.nix
@@ -6,6 +6,7 @@
 {
   xdg.configFile."espanso/config/default.yml".text = builtins.toJSON {
     search_trigger = ":search";
+    show_notifications = false;
     keyboard_layout = {
       model = config.home.keyboard.model;
       layout = config.home.keyboard.layout;


### PR DESCRIPTION
espanso sends lots of notifications - one for each time it starts and one every time the config is edited (which includes each home manager activation)

This is a little excessive - let's disable it