### PR TITLE
fix(minion): correct espanso matches

### DIFF
--- a/homes/minion/espanso.nix
+++ b/homes/minion/espanso.nix
@@ -34,12 +34,12 @@
   xdg.configFile."espanso/match/personal.yml".text = builtins.toJSON {
     matches = [
       {
-        regex = "@(c\.|companies)";
+        regex = ''@(c\.|companies)'';
         replace = "@companies.starrysky.fyi";
       }
       {
-        regex = "sky@a(?P<whitespace>\W)";
-        replace = "sky@a.starrysky.fyii{{whitespace}}";
+        regex = ''sky@a(?P<whitespace>\W)'';
+        replace = "sky@a.starrysky.fyi{{whitespace}}";
       }
       {
         trigger = ":co:me";


### PR DESCRIPTION
Previously I incorrectly had backslashes in speech marks, which were getting dropped by attempting to escape the next characters

I additionally made a typo in my email once, which I have also corrected