### PR TITLE
fix: correct xdg-portal open ordering

### DIFF
--- a/homes/niri/niri.nix
+++ b/homes/niri/niri.nix
@@ -316,5 +316,25 @@
         ExecStart = "${config.programs.niri.package}/bin/niri --session";
       };
     };
+
+    systemd.user.services.xdg-desktop-portal = {
+      # Overrides the portals from NixOS' `xdg.portal.enable`
+      Unit = {
+        Description = "Portal service";
+        PartOf = "graphical-session.target";
+        Requires = "dbus.service";
+        After = [
+          "dbus.service"
+          "niri.service"
+        ];
+      };
+
+      Service = {
+        Type = "dbus";
+        BusName = "org.freedesktop.portal.Desktop";
+        ExecStart = "${pkgs.xdg-desktop-portal}/libexec/xdg-desktop-portal";
+        Slice = "session.slice";
+      };
+    };
   };
 }


### PR DESCRIPTION
Previously the xdg-portal had stopped working (presumably when we started running niri with systemd...). It turns out that starting it after niri works!

Unfortunately, we only know of the use of niri in home, so we have to clone the serivce into niri.nix to make it work