### PR TITLE
fix: eliminate fetching for eval

### DIFF
--- a/systems/niri/niri.nix
+++ b/systems/niri/niri.nix
@@ -11,12 +11,10 @@
   ...
 }:
 let
-  package = pkgs.niri-unstable;
+  package = pkgs.niri;
 in
 {
   # we do not use the niri-flake nixos module, as it imports the home-module which causes a duplicate for attached homes
-
-  nixpkgs.overlays = [ project.inputs.niri.result.overlays.niri ];
 
   nix.settings = {
     substituters = [ "https://niri.cachix.org" ];


### PR DESCRIPTION
Previously we were fetching various things to evaluate our configuration

Some of it was collabora-gtimelog, which I removed by adding it to npins

The remainder was niri cargo lock dependencies, which are a little harder to fix. This said, we are currently tracking unstable niri which we don't really need to be doing: I've read through the changes from niri v25.05.1...main and I don't believe that any of them are important to us at the moment

Therefore, tracking nixpkgs niri fixes this for us

---

When niri gets significant updates we may want to revisit whether to use nixpkgs unstable on our systems/fetch only niri from unstable/etc.