### PR TITLE
fix(niri): Disable button areas on trackpad

### DIFF
--- a/homes/niri/niri.nix
+++ b/homes/niri/niri.nix
@@ -63,6 +63,7 @@
         };
 
         input.touchpad.natural-scroll = true;
+        input.touchpad.click-method = "clickfinger";
 
         input.warp-mouse-to-focus.enable = true;
         input.focus-follows-mouse = {


### PR DESCRIPTION
Previously if using tap to click niri would follow 1-2-3 finger tap methods however if actually clicking would follow button areas, we believe this inconsistoncy is more bugful