### PR TITLE
fix(minion): correct sky@a espanso regex

### DIFF
--- a/homes/minion/espanso.nix
+++ b/homes/minion/espanso.nix
@@ -38,7 +38,7 @@
         replace = "@companies.starrysky.fyi";
       }
       {
-        regex = ''sky@a(?P<whitespace>\W)'';
+        regex = ''sky@a(?P<whitespace>\s)'';
         replace = "sky@a.starrysky.fyi{{whitespace}}";
       }
       {


### PR DESCRIPTION
Previously I was accidentally using the "non-word character" regex class rather than the whitespace class. This led to sky@a. causing a menu to choose between these two. Let's fix that...