### PR TITLE
ci: add tangled.sh mirror

### DIFF
--- a/.github/workflows/tangled.yml
+++ b/.github/workflows/tangled.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+name: Mirror to tangled.sh
+
+on:
+  push:
+    branches: [ "main", "release" ]
+
+jobs:
+  tangled-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: cd $GITHUB_WORKSPACE
+
+      - name: Write out SSH key
+        env:
+          TANGLED_SSH_KEY: ${{ secrets.TANGLED_SSH_KEY }}
+        run: |
+          echo "$TANGLED_SSH_KEY" > ../tangled_ssh_key
+          chmod 600 ../tangled_ssh_key
+          
+      - name: Push to tangled
+        run: |         
+          git remote add tangled git@tangled.sh:freshlybakedca.ke/packetmix
+          export GIT_SSH_COMMAND="ssh -i $(realpath ../tangled_ssh_key) -o StrictHostKeyChecking=no"
+          git fetch --unshallow origin
+          git fetch tangled
+          git push tangled HEAD


### PR DESCRIPTION
We're interested in using tangled in the future due to its nicer stacked PR workflow than GitHub, though we will need CI to properly make the jump. Nevertheless, we believe it's worth mirroring our main/release branches over to tangled now so that anyone who wants to can pull from there