### PR TITLE
feat(zed): switch to helix mode

### DIFF
--- a/homes/development/collaboration.nix
+++ b/homes/development/collaboration.nix
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ pkgs, ... }:
+{ project, system, ... }:
 {
   programs.zed-editor = {
     enable = true;
+    package = project.inputs.nixos-unstable.result.${system}.zed-editor;
     extensions = [
       "catppuccin"
       "catppuccin-icons"
@@ -14,7 +15,7 @@
     userSettings = {
       git.git_gutter = "hide";
       minimap.show = "auto";
-      vim_mode = true;
+      helix_mode = true;
     };
   };
 }


### PR DESCRIPTION
PacketMix uses Helix as its main editor - let's set the Helix bindings in Zed too

From https://github.com/zed-industries/zed/issues/4642, Zed 0.193 and above have had the option to change to a Helix normal mode that will work more like what we're familiar with. Zed 0.193 is only in unstable so let's switch there for now too...