### PR TITLE
feat(zed): make edit predictions subtle

### DIFF
--- a/homes/development/collaboration.nix
+++ b/homes/development/collaboration.nix
@@ -12,6 +12,7 @@
       "nix"
     ];
     userSettings = {
+      edit_predictions.mode = "subtle";
       git.git_gutter = "hide";
       minimap.show = "auto";
       vim_mode = true;


### PR DESCRIPTION
We want AI features to be opt-in. We consider, however, holding alt to
be enough of an opt-in to let this stay. If you want to turn this off
entirely we recommend following:

https://zed.dev/docs/ai/edit-prediction#turning-off-completely