### PR TITLE
feat: add nix-index

### DIFF
--- a/homes/default.nix
+++ b/homes/default.nix
@@ -20,6 +20,7 @@ in
       ./gaming
       ./minion
       (import ./niri { inherit (config.inputs) niri walker; })
+      (import ./nix-index { inherit (config.inputs) nix-index-database; })
       ./remote
     ];
     args = {
@@ -40,6 +41,7 @@ in
       ./espanso
       ./gaming
       (import ./niri { inherit (config.inputs) niri walker; })
+      (import ./nix-index { inherit (config.inputs) nix-index-database; })
       ./remote
     ];
     args = {
@@ -59,6 +61,7 @@ in
       ./development
       ./espanso
       ./gaming
+      (import ./nix-index { inherit (config.inputs) nix-index-database; })
       ./remote
     ];
     args = {

--- a/homes/nix-index/default.nix
+++ b/homes/nix-index/default.nix
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ nix-index-database }:
+{
+  imports = [
+    (import ./nix-index.nix { inherit nix-index-database; })
+  ];
+}

--- a/homes/nix-index/nix-index.nix
+++ b/homes/nix-index/nix-index.nix
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ nix-index-database }:
+{ ... }:
+{
+  imports = [
+    nix-index-database.result.hmModules.nix-index
+  ];
+
+  config = {
+    programs.nix-index-database.comma.enable = true;
+    programs.nix-index.enable = true;
+  };
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -151,6 +151,19 @@
       "url": "https://github.com/sodiboo/niri-flake/archive/c4d9d4caa0c1e5c002679ca4b15db223b1942c2b.tar.gz",
       "hash": "sha256-tF7Tery/v0lhBKAwj9TgBLPSng42iZzlf/MeFb7on6U="
     },
+    "nix-index-database": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "nix-community",
+        "repo": "nix-index-database"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "85686025ba6d18df31cc651a91d5adef63378978",
+      "url": "https://github.com/nix-community/nix-index-database/archive/85686025ba6d18df31cc651a91d5adef63378978.tar.gz",
+      "hash": "sha256-DuOznGdgMxeSlPpUu6Wkq0ZD5e2Cfv9XRZeZlHWMd1s="
+    },
     "nixos-unstable": {
       "type": "Channel",
       "name": "nixos-unstable",


### PR DESCRIPTION
I need to find a particular path in nixpkgs - however the tool that does this (nix-index) is for some reason not installed by default. Let's install it along with the community database (to avoid generating things ourselves...)

I've made a new ingredient for this - I'm not entirely set on that. It's likely that we should move this into 'development' - or even 'packetmix'
- particularly as it contains comma and better command-not-found handling - myself and Coded should probably discuss that, which didn't happen here as this is effectively a drive-by patch for a thing I quickly need...