### PR TITLE
feat(redhead): round window corners

### DIFF
--- a/homes/default.nix
+++ b/homes/default.nix
@@ -28,6 +28,28 @@ in
       project = config;
     };
   };
+  config.homes."minion@redhead:x86_64-linux" = {
+    modules = [
+      {
+        home.stateVersion = "24.11";
+        home.homeDirectory = "/home/minion";
+      }
+      (import ./catppuccin { inherit (config.inputs) catppuccin; })
+      ./common
+      ./development
+      ./espanso
+      ./gaming
+      ./minion
+      (import ./niri { inherit (config.inputs) niri walker; })
+      (import ./nix-index { inherit (config.inputs) nix-index-database; })
+      ./redhead
+      ./remote
+    ];
+    args = {
+      system = "x86_64-linux";
+      project = config;
+    };
+  };
   config.homes."coded:x86_64-linux" = {
     modules = [
       {

--- a/homes/redhead/default.nix
+++ b/homes/redhead/default.nix
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+# depends on niri flavor
+{
+  imports = [
+    ./niri.nix
+  ];
+}

--- a/homes/redhead/niri.nix
+++ b/homes/redhead/niri.nix
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  programs.niri = {
+    settings = {
+      window-rules = [
+        {
+          geometry-corner-radius = {
+            top-left = 8.0;
+            top-right = 8.0;
+            bottom-left = 4.0;
+            bottom-right = 4.0;
+          };
+          clip-to-geometry = true;
+        }
+      ];
+    };
+  };
+}

--- a/systems/default.nix
+++ b/systems/default.nix
@@ -23,7 +23,7 @@ in
       system = "x86_64-linux";
       project = config;
     };
-    homes = { inherit (config.homes) "minion:x86_64-linux"; };
+    homes = { inherit (config.homes) "minion@redhead:x86_64-linux"; };
   };
   config.systems.nixos."emden" = {
     pkgs = nixpkgs.x86_64-linux;


### PR DESCRIPTION
I just updated the display on my framework laptop to the 2.8k one, and on it the corners are rounded. It makes sense, therefore, for me to round window corners to match. Doing this only for redhead means adding a new ingredient just for it, which also means making another home...

I have no specifications for how much the corners should be rounded - but the top corners seem to be about 8px with the bottom corners about 4px

I'm not entirely sure how good this'll look on external displays - I may still change this later