### PR TITLE
fix(niri): do not repeat overview open bind

### DIFF
--- a/homes/niri/niri.nix
+++ b/homes/niri/niri.nix
@@ -214,7 +214,10 @@
                 "${mod}+Shift+Ctrl+Home".action.move-workspace-to-monitor-left = [ ];
                 "${mod}+Shift+Ctrl+End".action.move-workspace-to-monitor-right = [ ];
 
-                "${mod}+Space".action.toggle-overview = [ ];
+                "${mod}+Space" = {
+                  action.toggle-overview = [ ];
+                  repeat = false;
+                };
               })
             // {
               # Audio


### PR DESCRIPTION
When held down, this bind causes a rapid open/close of the overview, which is both useless and uncomfortably-flickery. Turning off repeat fixes this