### PR TITLE
feat(jujutsu): change diff/merge tools

### DIFF
--- a/homes/development/default.nix
+++ b/homes/development/default.nix
@@ -9,6 +9,7 @@
     ./gpg.nix
     ./helix.nix
     ./hoppscotch.nix
+    ./jujutsu.nix
     ./simplified-utilities.nix
     ./tmux.nix
   ];

--- a/homes/development/jujutsu.nix
+++ b/homes/development/jujutsu.nix
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  project,
+  pkgs,
+  system,
+  ...
+}:
+{
+  home.packages = [
+    pkgs.difftastic
+    pkgs.meld
+    project.inputs.nixos-unstable.result.${system}.jujutsu
+  ];
+}

--- a/homes/development/jujutsu.nix
+++ b/homes/development/jujutsu.nix
@@ -11,7 +11,8 @@
 {
   home.packages = [
     pkgs.difftastic
-    pkgs.meld
+    pkgs.kdiff3
+    pkgs.mergiraf
     project.inputs.nixos-unstable.result.${system}.jujutsu
   ];
 }

--- a/systems/personal/configuration.nix
+++ b/systems/personal/configuration.nix
@@ -73,25 +73,18 @@
 
   # List packages installed in system profile. To search, run:
   # $ nix search wget
-  environment.systemPackages =
-    with pkgs;
-    [
-      #  vim # Do not forget to add an editor to edit configuration.nix! The Nano editor is also installed by default.
-      #  wget
-      git
-      helix
-      chromium
-      dogdns
-      ghostty
-      (project.inputs.npins.result { inherit pkgs system; })
-      thunderbird
-      difftastic
-      meld
-      wl-clipboard
-    ]
-    ++ [
-      project.inputs.nixos-unstable.result.${system}.jujutsu
-    ];
+  environment.systemPackages = with pkgs; [
+    #  vim # Do not forget to add an editor to edit configuration.nix! The Nano editor is also installed by default.
+    #  wget
+    git
+    helix
+    chromium
+    dogdns
+    ghostty
+    (project.inputs.npins.result { inherit pkgs system; })
+    thunderbird
+    wl-clipboard
+  ];
 
   # Some programs need SUID wrappers, can be configured further or are
   # started in user sessions.


### PR DESCRIPTION
Meld has some problems with diff editing
- Permissions become scuffed when you use copy from one place to another
- There's no real way to undo or get both sides - it's very barebones

Therefore, let's install the (more complex, unfortunately) kdiff3 for
use as a diff tool instead. We may want to change configuration on this
later to autoselect something different from its default "merge" option
and auto-un-collapse folders, presuming these are configurable

We also don't tend to use meld for resolving conflicts, so let's
install the mergiraf tool to add some value to `jj resolve` over manual
resolution