### PR TITLE
fix(gtk): add icon theme

### DIFF
--- a/homes/catppuccin/catppuccin.nix
+++ b/homes/catppuccin/catppuccin.nix
@@ -7,5 +7,4 @@
 {
   imports = [ catppuccin.result.homeModules.catppuccin ];
   config.catppuccin.enable = true;
-  config.catppuccin.gtk.enable = true;
 }

--- a/homes/common/default.nix
+++ b/homes/common/default.nix
@@ -6,6 +6,7 @@
   imports = [
     ./bash.nix
     ./files.nix
+    ./gtk.nix
     ./ghostty.nix
     ./helix.nix
     ./zoxide.nix

--- a/homes/common/gtk.nix
+++ b/homes/common/gtk.nix
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, ... }:
+{
+  gtk = {
+    enable = true;
+    iconTheme = {
+      package = pkgs.adwaita-icon-theme;
+      name = "Adwaita";
+    };
+  };
+}


### PR DESCRIPTION
We currently have various gtk apps that don't have an icon theme, which means they show broken icons...

Also: It turns out that the catppuccin gtk theme is deprecated (why it's not on by default) and depends on gtk being enabled *anyway*, so best to remove that line from our configuration as it was a no-op