### PR TITLE
feat: make quickshell smaller on vertical monitors

### DIFF
--- a/homes/niri/quickshell/shell.qml
+++ b/homes/niri/quickshell/shell.qml
@@ -38,6 +38,8 @@ Scope {
         model: Quickshell.screens
 
         PanelWindow {
+            id: shell
+
             anchors {
                 top: true
                 left: true
@@ -59,10 +61,19 @@ Scope {
                 id: overviewTopline
                 visible: Niri.overview
 
-                y: (parent.height / 5)
+                QtObject {
+                    id: position
+
+                    property int vmin: Math.min(shell.width, shell.height)
+                    property int height: vmin * 1 / 20
+                    property int toplineAreaBottom: shell.height / 4
+                    property int y: toplineAreaBottom - height
+                }
+
+                y: position.y
 
                 width: parent.width
-                height: parent.height * 1 / 20
+                height: position.height
 
                 color: "transparent"
 


### PR DESCRIPTION
Quickshell is currently too big for us to really add other widgets, so it would make more sense to shrink it - here we use something that's akin to css' vmin to decide how tall the area should be.

We decided to anchor the area to the top of the window (rather than the center of the available area). Without doing so the bar looks weird when we have the top workspace focused (i.e. a lot of the time). It's also meant to be some sort of a bar-like thing (so anchoring it makes sense).