### PR TITLE
fix(niri): use same package for system and home

### DIFF
--- a/homes/niri/niri.nix
+++ b/homes/niri/niri.nix
@@ -59,7 +59,7 @@
       {
         enable = true;
 
-        package = project.inputs.niri.result.packages.${pkgs.system}.niri-unstable;
+        package = pkgs.niri;
 
         settings = {
           environment = {


### PR DESCRIPTION
We're using a lot of time/space building niri, but actually we are only using the version from nixpkgs anyway because we aren't using standalone homes beyond a CI build - let's stop wasting resources