### PR TITLE
init(teal): add modules

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1,5 +1,57 @@
 {
   "pins": {
+    "beancount-autobean": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "SEIAROTg",
+        "repo": "autobean"
+      },
+      "branch": "master",
+      "submodules": false,
+      "revision": "b14d040eaa75a55731ef650e76425d7d356ec2b9",
+      "url": "https://github.com/SEIAROTg/autobean/archive/b14d040eaa75a55731ef650e76425d7d356ec2b9.tar.gz",
+      "hash": "sha256-+AFC78RzFITV7nNvg3PVUszsBW9b4tVHpVAjcPT2+4s="
+    },
+    "beancount-beancount_plugin_utils": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "Akuukis",
+        "repo": "beancount_plugin_utils"
+      },
+      "branch": "master",
+      "submodules": false,
+      "revision": "053807f55b062a4d7bca91612a856da3812cb465",
+      "url": "https://github.com/Akuukis/beancount_plugin_utils/archive/053807f55b062a4d7bca91612a856da3812cb465.tar.gz",
+      "hash": "sha256-oyfL2K/sS4zZ7cq1P36h0dTcW1m5GUyQ9+IyZGfpb2E="
+    },
+    "beancount-beancount_share": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "Akuukis",
+        "repo": "beancount_share"
+      },
+      "branch": "master",
+      "submodules": false,
+      "revision": "4101c45e16948c0683520cebcf88afe4862224c4",
+      "url": "https://github.com/Akuukis/beancount_share/archive/4101c45e16948c0683520cebcf88afe4862224c4.tar.gz",
+      "hash": "sha256-BW2KEC0pmervT71FBixPcQciEuGcElCd2wW7BZL1xUg="
+    },
+    "beancount-smart_importer": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "beancount",
+        "repo": "smart_importer"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "d288eb31c580883491294c5e6c0abb4962f16e79",
+      "url": "https://github.com/beancount/smart_importer/archive/d288eb31c580883491294c5e6c0abb4962f16e79.tar.gz",
+      "hash": "sha256-1hE/2za1grfCeo1UK81dpLL/JkiLgaRYqLtF09mbDHc="
+    },
     "catppuccin": {
       "type": "Git",
       "repository": {

--- a/packages/beancount-autobean/default.nix
+++ b/packages/beancount-autobean/default.nix
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ config, ... }:
+{
+  config.packages.beancount-autobean = {
+    systems = [ "x86_64-linux" ];
+    package =
+      {
+        lib,
+        python3,
+      }:
+      let
+        pname = "autobean";
+        version = "0.2.2";
+      in
+      python3.pkgs.buildPythonApplication {
+        inherit pname version;
+
+        src = config.inputs.beancount-autobean.src;
+
+        format = "pyproject";
+
+        propagatedBuildInputs = [
+          python3.pkgs.beancount
+          python3.pkgs.python-dateutil
+          python3.pkgs.pyyaml
+          python3.pkgs.requests
+        ];
+
+        buildInputs = [
+          python3.pkgs.setuptools
+          python3.pkgs.pdm-pep517
+        ];
+
+        meta = {
+          homepage = "https://github.com/SEIAROTg/autobean";
+          description = "A collection of plugins and scripts that help automating bookkeeping with beancount";
+          license = lib.licenses.gpl2;
+          maintainers = [ lib.maintainers.minion3665 ];
+        };
+      };
+
+  };
+}

--- a/packages/beancount-beancount_plugin_utils/default.nix
+++ b/packages/beancount-beancount_plugin_utils/default.nix
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ config, ... }:
+{
+  config.packages.beancount-beancount_plugin_utils = {
+    systems = [ "x86_64-linux" ];
+    package =
+      {
+        lib,
+        python3,
+      }:
+      let
+        pname = "beancount_plugin_utils";
+        version = "0.0.4";
+      in
+      python3.pkgs.buildPythonApplication {
+        inherit pname version;
+
+        src = config.inputs.beancount-beancount_plugin_utils.src;
+
+        format = "pyproject";
+
+        propagatedBuildInputs = [
+          python3.pkgs.beancount
+        ];
+
+        buildInputs = [
+          python3.pkgs.setuptools
+          python3.pkgs.pdm-pep517
+        ];
+
+        meta = {
+          homepage = "https://github.com/Akuukis/beancount_plugin_utils";
+          description = ''
+            Utils for beancount plugin writers - BeancountError, mark, metaset, etc.
+
+                    Not ready for public use, but used by various Akuukis plugins.
+                    Appears unmaintained'';
+          license = lib.licenses.agpl3Only;
+          maintainers = [ lib.maintainers.minion3665 ];
+        };
+      };
+  };
+}

--- a/packages/beancount-beancount_share/default.nix
+++ b/packages/beancount-beancount_share/default.nix
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ config, ... }:
+{
+  config.packages.beancount-beancount_share = {
+    systems = [ "x86_64-linux" ];
+    package =
+      {
+        system,
+        lib,
+        python3,
+      }:
+      let
+        pname = "beancount_share";
+        version = "0.1.10";
+      in
+      python3.pkgs.buildPythonApplication {
+        inherit pname version;
+
+        src = config.inputs.beancount-beancount_share.src;
+
+        format = "pyproject";
+
+        propagatedBuildInputs = [
+          python3.pkgs.beancount
+          config.packages.beancount-beancount_plugin_utils.result.${system}
+        ];
+
+        buildInputs = [
+          python3.pkgs.setuptools
+          python3.pkgs.pdm-pep517
+        ];
+
+        meta = {
+          homepage = "https://github.com/Akuukis/beancount_share";
+          description = "A beancount plugin to share expenses with external partners within one ledger.";
+          license = lib.licenses.agpl3Only;
+          maintainers = [ lib.maintainers.minion3665 ];
+        };
+      };
+  };
+}

--- a/packages/beancount-smart_importer/default.nix
+++ b/packages/beancount-smart_importer/default.nix
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ config, ... }:
+{
+  config.packages.beancount-smart_importer = {
+    systems = [ "x86_64-linux" ];
+    package =
+      {
+        lib,
+        python3,
+      }:
+      let
+        pname = "smart_importer";
+        version = "0.5";
+      in
+      python3.pkgs.buildPythonApplication {
+        inherit pname version;
+
+        src = config.inputs.beancount-smart_importer.result;
+
+        format = "pyproject";
+
+        propagatedBuildInputs = [
+          python3.pkgs.beancount
+          python3.pkgs.scikit-learn
+          python3.pkgs.numpy
+          python3.pkgs.beangulp
+        ];
+
+        buildInputs = [
+          python3.pkgs.setuptools
+          python3.pkgs.setuptools_scm
+        ];
+
+        meta = {
+          homepage = "https://github.com/beancount/smart_importer";
+          description = "Augment Beancount importers with machine learning functionality";
+          license = lib.licenses.mit;
+          maintainers = [ lib.maintainers.minion3665 ];
+        };
+      };
+  };
+}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -4,6 +4,10 @@
 
 {
   includes = [
+    ./beancount-autobean
+    ./beancount-beancount_plugin_utils
+    ./beancount-beancount_share
+    ./beancount-smart_importer
     ./collabora-gtimelog
     ./treefmt
   ];

--- a/systems/teal/acme.nix
+++ b/systems/teal/acme.nix
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  security.acme = {
+    defaults = {
+      email = "acme@freshlybakedca.ke";
+      dnsProvider = "cloudflare";
+      environmentFile = "/secrets/acme/environmentFile";
+    };
+  };
+}

--- a/systems/teal/default.nix
+++ b/systems/teal/default.nix
@@ -4,7 +4,13 @@
 
 {
   imports = [
+    ./acme.nix
+    ./fava.nix
     ./hardware-configuration.nix
+    ./headscale.nix
     ./hostname.nix
+    ./packetmix.nix
+    ./secrets.nix
+    ./silverbullet.nix
   ];
 }

--- a/systems/teal/fava.nix
+++ b/systems/teal/fava.nix
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  project,
+  pkgs,
+  lib,
+  system,
+  ...
+}:
+let
+  /**
+    These users are listed in a specific order: this is the order they will show up in the fava dropdown menu (the first one being the default)
+    - The "slug" is user visible - it's the name of the config file which is displayed in the UI in a few places. Changing this will lose the userdata unless it is manually copied
+    - The "name" is the name that gets actually shown as the account name in the UI
+    - The "beancountOptions" are documented here: <https://beancount.github.io/docs/beancount_options_reference.html>. They get written to a read-only file in the nix store
+    - The "favaOptions" are documented here - <https://fava.pythonanywhere.com/huge-example-file/help/options>. They get written alongside the beancount options
+    - The "extraConfig" also gets written alongside the beancount options
+  */
+  users = [
+    {
+      slug = "freshlybakedcake";
+      name = "FreshlyBakedCake";
+      beancountOptions.operating_currency = "GBP";
+    }
+    {
+      slug = "minion";
+      name = "Skyler Grey";
+      beancountOptions.operating_currency = "GBP";
+      favaOptions = {
+        invert-income-liabilities-equity = "true";
+        auto-reload = "true";
+        fiscal-year-end = "04-05";
+        import-config = builtins.toString ./fava/minion/truelayer.py;
+        import-dirs = "/var/lib/private/fava/minion/";
+      };
+      extraConfig = ''
+        plugin "fava.plugins.tag_discovered_documents"
+        plugin "fava.plugins.link_documents"
+
+        plugin "beancount.plugins.pedantic"
+        plugin "beancount.plugins.unrealized" "Unrealized"
+        plugin "beancount.plugins.implicit_prices"
+
+        plugin "beancount_share.share" "{
+          'mark_name': 'share',
+          'meta_name': 'shared',
+          'account_debtors': 'Assets:People',
+          'account_creditors': 'Liabilities:People',
+          'open_date': None,
+          'quantize': '0.01'
+        }"
+      '';
+    }
+    {
+      slug = "coded";
+      name = "Samuel Shuert";
+      beancountOptions.operating_currency = "USD";
+    }
+  ];
+
+  userConfigs =
+    (map (
+      user:
+      lib.recursiveUpdate {
+        beancountOptions.title = user.name;
+        favaOptions.default-file = "/var/lib/private/fava/${user.slug}.beancount";
+      } user
+    ))
+      users;
+
+  userFiles =
+    (map (
+      userConfig:
+      builtins.toString (
+        let
+          generateFavaOption =
+            name: value:
+            if value == null then
+              ''1970-01-01 custom "fava-option" "${name}"''
+            else
+              ''1970-01-01 custom "fava-option" "${name}" "${value}"'';
+          favaOptions = lib.pipe userConfig.favaOptions [
+            (lib.attrsets.mapAttrsToList generateFavaOption)
+            (lib.strings.concatStringsSep "\n")
+          ];
+
+          generateBeancountOption = name: value: ''option "${name}" "${value}"'';
+          beancountOptions = lib.pipe userConfig.beancountOptions [
+            (lib.attrsets.mapAttrsToList generateBeancountOption)
+            (lib.strings.concatStringsSep "\n")
+          ];
+        in
+        pkgs.writeText "${userConfig.slug}-config" ''
+          ${favaOptions}
+          ${beancountOptions}
+          ${userConfig.extraConfig or ""}
+
+          include "${userConfig.favaOptions.default-file}"
+        ''
+      )
+    ))
+      userConfigs;
+in
+{
+  systemd.services.fava = {
+    requires = [ "nginx.service" ];
+    after = [ "nginx.service" ];
+    wantedBy = [ "multi-user.target" ];
+
+    environment = {
+      FAVA_HOST = "127.0.0.1";
+      FAVA_PORT = "1025";
+    };
+
+    serviceConfig = {
+      StateDirectory = "fava";
+      DynamicUser = true;
+      LoadCredential = [
+        "truelayer_client_secret:/secrets/fava/truelayer_client_secret"
+      ];
+    };
+
+    script =
+      let
+        fava = pkgs.fava.overrideAttrs (prevAttrs: {
+          propagatedBuildInputs = prevAttrs.propagatedBuildInputs ++ [
+            project.packages.beancount-autobean.result.${system}
+            project.packages.beancount-beancount_share.result.${system}
+            project.packages.beancount-smart_importer.result.${system}
+          ];
+        });
+      in
+      "${fava}/bin/fava ${builtins.concatStringsSep " " userFiles}";
+
+    preStart =
+      let
+        userConfigToCreationScript = userConfig: ''
+          ${pkgs.coreutils}/bin/mkdir -p "$(${pkgs.coreutils}/bin/dirname "${userConfig.favaOptions.default-file}")"
+          ${pkgs.coreutils}/bin/touch -a ${userConfig.favaOptions.default-file}
+        '';
+      in
+      lib.trivial.pipe userConfigs [
+        (map userConfigToCreationScript)
+        (lib.strings.concatStringsSep "\n")
+      ];
+  };
+
+  services.nginx.enable = true;
+  services.nginx.virtualHosts."fava.clicks.codes" = {
+    locations."/" = {
+      proxyPass = "http://127.0.0.1:1025";
+      recommendedProxySettings = true;
+    };
+  };
+
+  services.nginx.tailscaleAuth = {
+    enable = true;
+    virtualHosts = [ "fava.clicks.codes" ];
+  };
+
+  clicks.storage.impermanence.persist.directories = [
+    {
+      directory = "/var/lib/private/fava";
+      mode = "0700";
+      defaultPerms.mode = "0700";
+    }
+  ];
+}

--- a/systems/teal/fava/minion/truelayer.py
+++ b/systems/teal/fava/minion/truelayer.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+import autobean.truelayer
+from smart_importer import apply_hooks, PredictPayees, PredictPostings
+
+import os
+import pathlib
+
+with open(pathlib.Path(os.environ["CREDENTIALS_DIRECTORY"]) / pathlib.Path("truelayer_client_secret")) as f:
+  truelayer_client_secret = f.read().strip()
+
+CONFIG = [
+  apply_hooks(
+    autobean.truelayer.Importer(
+      "fava-228732",
+      truelayer_client_secret
+    ),
+    [
+      PredictPayees(),
+      PredictPostings(),
+    ]
+  )
+]

--- a/systems/teal/headscale.nix
+++ b/systems/teal/headscale.nix
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: 2024 Clicks Codes
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, ... }:
+let
+  groups = {
+    /**
+      Users have full access to contact other users or servers
+
+      This gives them access to internal-only things such as all SilverBullet
+      notes on https://silverbullet.clicks.codes or finance information on
+      https://fava.clicks.codes
+
+      They tend to be either close friends, people who host servers on our
+      network or straight-up Clicks or Freshly Baked Cake developers
+
+      Servers are owned by users but have the tag `tag:server` to give them a
+      different permission level. Servers can only access other servers
+    */
+    "group:users" = [
+      "coded"
+      "matei"
+      "minion"
+      "pineafan"
+      "zanderp25"
+      "mostlyturquoise"
+    ];
+
+    /**
+      Friends only have access to other users
+
+      This doesn't give them access to internal-only services, but it could let
+      them join, say, Minecraft servers which are owned by someone else on the
+      tailnet
+    */
+    "group:friends" = [
+      "sirdigalot"
+    ];
+  };
+
+  exceptional_acls = [
+    {
+      action = "accept";
+      src = [ "zulu" ];
+      dst = [ "zanderp25:3000" ];
+    } # Used to let Zan reverse proxy to their personal machine for development - port-locked so probably OK
+    {
+      action = "accept";
+      src = [ "mostlyturquoise" ];
+      dst = [ "tag:mostlyturquoise-minecraft-server" ];
+    } # Used to let mostlyturquoise and their friends access their minecraft servers without giving people too many permissions
+  ];
+
+  acls = [
+    {
+      action = "accept";
+      src = [ "group:users" ];
+      dst = [
+        "group:users:*"
+        "group:friends:*"
+        "autogroup:internet:*"
+        "tag:server:*"
+      ];
+    }
+    {
+      action = "accept";
+      src = [ "group:friends" ];
+      dst = [
+        "group:users:*"
+        "group:friends:*"
+      ];
+    }
+    {
+      action = "accept";
+      src = [ "tag:server" ];
+      dst = [ "tag:server:*" ];
+    }
+  ] ++ exceptional_acls;
+
+  tagOwners = [
+    {
+      name = "tag:server";
+      value = "group:users";
+    }
+    {
+      name = "tag:mostlyturquoise-minecraft-server";
+      value = "mostlyturquoise";
+    }
+  ];
+in
+{
+  # Headscale service
+  services.headscale = {
+    enable = true;
+
+    address = "127.0.0.1";
+    port = 1024;
+
+    settings = {
+      server_url = "https://vpn.clicks.codes";
+      noise.private_key_path = "/secrets/headscale/noise_private_key";
+      policy = {
+        mode = "file";
+        path = (
+          pkgs.writers.writeJSON "tailscale-acls.json" {
+            inherit groups acls tagOwners;
+          }
+        );
+      };
+      dns = {
+        nameservers.global = [
+          "1.1.1.1"
+          "1.0.0.1"
+          "2606:4700:4700::1111"
+          "2606:4700:4700::1001"
+        ];
+        base_domain = "clicks.domains";
+      };
+      oidc = {
+        only_start_if_oidc_is_available = false; # Otherwise we can end up locking ourselves out...
+        strip_email_domain = true;
+
+        issuer = "https://login.clicks.codes/realms/master";
+
+        client_id = "headscale";
+        client_secret_path = "/secrets/headscale/oidc_client_secret";
+
+        allowed_groups = [ "/clicks" ];
+      };
+    };
+  };
+
+  # Nginx
+  services.nginx.enable = true;
+  services.nginx.virtualHosts."vpn.clicks.codes" = {
+    locations."/" = {
+      proxyPass = "http://127.0.0.1:1024";
+      recommendedProxySettings = true;
+      proxyWebsockets = true;
+    };
+  };
+
+  # Impermanence
+  clicks.storage.impermanence.persist.directories = [ "/var/lib/headscale" ];
+}

--- a/systems/teal/packetmix.nix
+++ b/systems/teal/packetmix.nix
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  clicks.storage.impermanence.persist.directories = [ "/etc/nixos" ];
+}

--- a/systems/teal/secrets.nix
+++ b/systems/teal/secrets.nix
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  clicks.storage.impermanence.persist.directories = [ "/secrets" ];
+}

--- a/systems/teal/silverbullet.nix
+++ b/systems/teal/silverbullet.nix
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  project,
+  system,
+  config,
+  ...
+}:
+{
+  clicks.storage.impermanence.persist.directories = [
+    {
+      directory = config.services.silverbullet.spaceDir;
+      mode = "0700";
+      defaultPerms.mode = "0700";
+    }
+  ];
+
+  services.silverbullet = {
+    enable = true;
+    listenPort = 1026;
+    listenAddress = "127.0.0.1";
+    package = project.inputs.nixos-unstable.result.${system}.silverbullet;
+  };
+
+  services.nginx.enable = true;
+  services.nginx.virtualHosts."silverbullet.clicks.codes" = {
+    locations."/" = {
+      proxyPass = "http://127.0.0.1:1026";
+      recommendedProxySettings = true;
+    };
+  };
+
+  services.nginx.tailscaleAuth = {
+    enable = true;
+    virtualHosts = [ "silverbullet.clicks.codes" ];
+  };
+}


### PR DESCRIPTION
We previously had various stuff running on teal from Infra/NixFiles

We've adapted our modules to work outside that environment (many of them depended on overly-complex clicks constructs) and moved them over so we can start deploying teal from PacketMix