### PR TITLE
feat(teal): migrate vaultwarden

### DIFF
--- a/systems/teal/default.nix
+++ b/systems/teal/default.nix
@@ -15,5 +15,6 @@
     ./secrets.nix
     ./silverbullet.nix
     ./tailscale.nix
+    ./vaultwarden.nix
   ];
 }

--- a/systems/teal/vaultwarden.nix
+++ b/systems/teal/vaultwarden.nix
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+{
+  services.vaultwarden = {
+    enable = true;
+    dbBackend = "postgresql";
+
+    config = {
+      # Server Settings
+      DOMAIN = "https://vaultwarden.clicks.codes"; # Not moving off the clicks domain due to passkey migration - maybe at a later date...
+      ROCKET_ADDRESS = "127.0.0.1";
+      ROCKET_PORT = 1028;
+
+      # Mail Settings
+      SMTP_HOST = "mail.clicks.codes"; # FIXME: switch to mail.freshly.space when the time is right...
+      SMTP_FROM = "vaultwarden@clicks.codes";
+      SMTP_FROM_NAME = "Clicks vaultwarden";
+      SMTP_SECURITY = "starttls";
+      SMTP_PORT = 587;
+      SMTP_USERNAME = "vaultwarden@clicks.codes";
+
+      REQUIRE_DEVICE_EMAIL = true;
+
+      # General Settings
+      SIGNUPS_ALLOWED = false;
+      INVITATIONS_ALLOWED = true;
+      SIGNUPS_DOMAINS_WHITELIST = builtins.concatStringsSep "," [
+        "a.starrysky.fyi"
+        "clicks.codes"
+        "freshlybakedca.ke"
+        "hopescaramels.com"
+        "thecoded.prof"
+        "trans.gg"
+        "turquoise.fyi"
+      ];
+      # This is similar to our mail domains, with the following changes
+      # - Add trans.gg
+      # - Remove special purpose domains
+      # - Remove deprecated domains
+      # - Deduplicate to a single canonical domain per group
+      SIGNUPS_VERIFY = true;
+
+      DISABLE_2FA_REMEMBER = true;
+
+      IP_HEADER = "X-Forwarded-For";
+
+      # YubiKey Settings
+      YUBICO_CLIENT_ID = "89788";
+
+      ORG_ENABLE_GROUPS = true;
+      # I have looked at the risks. They seem relatively small in comparison
+      # to the utility (stuff like sync issues if you don't refresh your page)
+      # Additionally, we have run with this in production for a significant
+      # amount of time with no noticed adverse effects...
+
+      DATABASE_URL = "postgresql:///vaultwarden?host=/run/postgresql";
+    };
+
+    environmentFile = "/secrets/vaultwarden/secrets.env";
+  };
+
+  systemd.services.vaultwarden = {
+    requires = [ "postgresql.service" ];
+    after = [ "postgresql.service" ];
+  };
+
+  services.postgresql = {
+    enable = true;
+    ensureDatabases = [ "vaultwarden" ];
+    ensureUsers = [
+      {
+        name = "vaultwarden";
+        ensureDBOwnership = true;
+
+      }
+    ];
+  };
+
+  services.nginx.enable = true;
+  services.nginx.virtualHosts."vaultwarden.clicks.codes" = {
+    addSSL = true;
+    enableACME = true;
+    acmeRoot = null;
+
+    locations."/" = {
+      proxyPass = "http://127.0.0.1:1028";
+      recommendedProxySettings = true;
+      proxyWebsockets = true;
+    };
+  };
+
+  clicks.storage.impermanence.persist.directories = [
+    "/var/lib/postgresql"
+    "/var/lib/vaultwarden"
+  ];
+}


### PR DESCRIPTION
As part of our ongoing effort to migrate off the old midnight config, we are moving our vaultwarden server to teal. The config here is largely the same. We are, however, on a higher stateVersion making the storage path change.

Additionally, we handle secrets rather differently - notably:
- postgresql is now connecting over a local socket so does not need a password
- everything else is split over two environment files: a secret one (manually created in /secrets) and a regular one (created by the nix module using the normal settings options)