### PR TITLE
feat(minion): add timelog espanso expansions

### DIFF
--- a/homes/minion/espanso.nix
+++ b/homes/minion/espanso.nix
@@ -23,6 +23,58 @@
       }
     ];
   };
+  xdg.configFile."espanso/match/collabora-timesheets.yml".text = builtins.toJSON {
+    matches = [
+      {
+        regex = '':t(?P<name>[^\s-]+)-?meet'';
+        replace = "productivity: r&d-productivity: project-admin: internal-meeting: {{name}}-meeting";
+      }
+      {
+        trigger = ":tevent";
+        replace = "collabora: business-development: event-attendance: event-attendee: ";
+      }
+      {
+        trigger = ":tmail";
+        replace = "collabora: internal: communications: e-mails: read emails";
+      }
+      {
+        trigger = ":tmeet";
+        replace = "productivity: r&d-productivity: project-admin: internal-meeting: ";
+      }
+      {
+        trigger = ":tmentor";
+        replace = "productivity: r&d-productivity: up-stream: mentoring: ";
+      }
+      {
+        trigger = ":tmobile";
+        replace = "productivity: r&d-productivity: product: collabora-online-25-04: mobile release";
+      }
+      {
+        trigger = ":trnd";
+        replace = "productivity: r&d-productivity: product: collabora-online-25-04: ";
+      }
+      {
+        trigger = ":tstat";
+        replace = "collabora: internal: communications: e-mails: status report";
+      }
+      {
+        trigger = ":ttrain";
+        replace = "collabora: internal-training: training: attendance: ";
+      }
+      {
+        trigger = ":tttt";
+        replace = "productivity: r&d-productivity: tea-time-training: tea-time-training: ";
+      }
+      {
+        trigger = '':tah'';
+        replace = "productivity: r&d-productivity: project-admin: internal-meeting: all hands meeting";
+      }
+      {
+        trigger = '':tcwm'';
+        replace = "productivity: r&d-productivity: project-admin: internal-meeting: cool-weekly-meeting";
+      }
+    ];
+  };
   xdg.configFile."espanso/match/javascript.yml".text = builtins.toJSON {
     matches = [
       {


### PR DESCRIPTION
I have various timelogging codes that I need to type every so often, and it would be nice if I was able to just type short versions instead of finding the full thing (with dodgy autocomplete in Collabora Gtimelog)

I've used t (for time) as a prefix, mostly to avoid clashes between :me and other things (:meet, :mentor)