### PR TITLE
fix(kanidm): correct personal client URL

### DIFF
--- a/systems/freshlybakedcake+personal/kanidm.nix
+++ b/systems/freshlybakedcake+personal/kanidm.nix
@@ -9,6 +9,6 @@
 
     package = pkgs.kanidm_1_6;
 
-    clientSettings.uri = "https://kanidm.freshly.space";
+    clientSettings.uri = "https://idm.freshly.space";
   };
 }


### PR DESCRIPTION
When I originally added kanidm to our personal configs I had used a file in .config for testing which overrode the incorrect URL in this module

I have tested this config change properly this time