### PR TITLE
feat: add davfs2

### DIFF
--- a/systems/freshlybakedcake+personal/dav.nix
+++ b/systems/freshlybakedcake+personal/dav.nix
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  services.davfs2 = {
+    enable = true;
+    settings.globalSection = {
+      # This is the max size of a single file in stalwart
+      cache_size = 8192;
+
+      # If we don't do this, we end up with larger files in lost+found
+      use_locks = 0;
+      drop_weak_etags = 1;
+    };
+  };
+
+  systemd.mounts = [
+    {
+      description = "Stalwart dav mount";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      what = "https://mail.freshly.space/dav/file";
+      where = "/mnt/freshly";
+      options = "x-systemd.automount,uid=1000,gid=100";
+      type = "davfs";
+    }
+  ];
+
+  systemd.automounts = [
+    {
+      description = "Stalwart dav automount";
+      where = "/mnt/freshly";
+      wantedBy = [ "multi-user.target" ];
+      automountConfig = {
+        TimeoutIdleSec = "2m";
+      };
+    }
+  ];
+}

--- a/systems/freshlybakedcake+personal/default.nix
+++ b/systems/freshlybakedcake+personal/default.nix
@@ -4,6 +4,7 @@
 
 {
   imports = [
+    ./dav.nix
     ./kanidm.nix
   ];
 }


### PR DESCRIPTION
After we set up stalwart we now have it as a webdav mount for file sharing. Let's set up some code to mount it by default

If you don't do this, you'll get a "no such device" error when you attempt to access /mnt/freshly. As the automount doesn't do anything until you attempt to use the folder you won't get an error beforehand

Finally, this does mean that you may not want to mount directly over /mnt - it doesn't stop you from doing so but that will then shadow this mount