### PR TITLE
fix(niri): start ssh-agent later

### DIFF
--- a/homes/niri/default.nix
+++ b/homes/niri/default.nix
@@ -11,6 +11,7 @@
   imports = [
     (import ./niri.nix { inherit niri walker; })
     (import ./quickshell { inherit home-manager-unstable; })
+    ./ssh.nix
     ./swaync.nix
   ];
 }

--- a/homes/niri/ssh.nix
+++ b/homes/niri/ssh.nix
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ lib, ... }:
+{
+  systemd.user.services.ssh-agent = {
+    Install.WantedBy = lib.mkForce [ "graphical-session.target" ];
+    Unit.After = [ "niri.service" ];
+  };
+
+  services.gnome-keyring.components = [
+    "pkcs11"
+    "secrets"
+  ]; # all excluding ssh
+}


### PR DESCRIPTION
Since switching niri to a systemd service we have gained some problems with ssh-agent: it needs a restart to work.

We can't trivially pull niri later since gnome-keyring ssh wants to be started as part of graphical-session-pre and depends on ssh-agent. To fix this we can disable the gnome-keyring ssh module.