### PR TITLE
chore: freeze stalwart

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -268,7 +268,8 @@
       "version": "v0.13.1",
       "revision": "00daa696080418c12715e58ee0561e0c90478084",
       "url": "https://api.github.com/repos/stalwartlabs/stalwart/tarball/refs/tags/v0.13.1",
-      "hash": "sha256-6zoI+yvE1Ep5jh9XthDqphm2zBA4UzhfK7VCKRWIH8g="
+      "hash": "sha256-6zoI+yvE1Ep5jh9XthDqphm2zBA4UzhfK7VCKRWIH8g=",
+      "frozen": true
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
Stalwart needs intervention to upgrade so it is preventing our automated npins dependency bump... for now, let's disable it upgrading automatically