### PR TITLE
feat(teal): add Copyparty

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -161,6 +161,22 @@
       "url": "https://git.lix.systems/lix-project/nixos-module/archive/4d4c2b8f0a801c91ce5b717c77fe3a17efa1402f.tar.gz",
       "hash": "sha256-gbpuESxl/An4GTh7QEbQRYJozVIxWkwVGbWK0/0GoRc="
     },
+    "lua-multipart": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "Kong",
+        "repo": "lua-multipart"
+      },
+      "pre_releases": true,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "0.5.10-1",
+      "revision": "f48e5f96db7fdcfd3f9983a4c3196ccabff868bc",
+      "url": "https://api.github.com/repos/Kong/lua-multipart/tarball/refs/tags/0.5.10-1",
+      "hash": "sha256-V9ZVVU8YK6d+zPZfRwsD/v5+PZFuUktMBpSKDPhVPTU="
+    },
     "nilla": {
       "type": "GitRelease",
       "repository": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -78,6 +78,22 @@
       "url": "https://gitlab.collabora.com/api/v4/projects/collabora%2Fgtimelog/repository/archive.tar.gz?sha=8395ec4576cf54411d974675d26f64208acdcee0",
       "hash": "sha256-M9pCF+XVf5ylxgq0BSUn5Vkg1HZ6i88LDiUDM4Y1Ghs="
     },
+    "copyparty": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "9001",
+        "repo": "copyparty"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "v1.18.9",
+      "revision": "ca22cd88534f48f13b18fc13eab9fdafca83a471",
+      "url": "https://api.github.com/repos/9001/copyparty/tarball/refs/tags/v1.18.9",
+      "hash": "sha256-3ziocVJcVQ0cBia8Sp91uMkcVdh6l4rm/huhvAKfXzA="
+    },
     "home-manager": {
       "type": "Git",
       "repository": {

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -9,6 +9,7 @@
     ./beancount-beancount_share
     ./beancount-smart_importer
     ./collabora-gtimelog
+    ./lua-multipart
     ./treefmt
   ];
 }

--- a/packages/lua-multipart/default.nix
+++ b/packages/lua-multipart/default.nix
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ config, ... }:
+{
+  config.packages.lua-multipart = {
+    systems = [ "x86_64-linux" ];
+
+    package =
+      {
+        lib,
+        luaPackages,
+        ...
+      }:
+      luaPackages.buildLuarocksPackage {
+        pname = "multipart";
+        version = config.inputs.lua-multipart.src.version;
+
+        src = config.inputs.lua-multipart.src;
+
+        meta = {
+          homepage = "https://github.com/Kong/lua-multipart";
+          description = "Multipart Parser for Lua";
+          maintainers = [ lib.maintainers.minion3665 ];
+          license = lib.licenses.mit;
+        };
+      };
+  };
+}

--- a/systems/teal/copyparty.nix
+++ b/systems/teal/copyparty.nix
@@ -75,22 +75,20 @@
               A = admins;
             };
           };
-          "/coded" = {
-            path = "/var/lib/copyparty/data/coded";
+          "/users/_" = {
+            path = "/var/lib/copyparty/data/users/_";
+
+            access = { };
+          };
+          "/users/\${u}" = {
+            path = "/var/lib/copyparty/data/users/_/\${u}";
 
             access = {
-              A = "coded";
+              A = "\${u}";
             };
           };
-          "/minion" = {
-            path = "/var/lib/copyparty/data/minion";
-
-            access = {
-              A = "minion";
-            };
-          };
-          "/freshly" = {
-            path = "/var/lib/copyparty/data/freshly";
+          "/groups/freshly" = {
+            path = "/var/lib/copyparty/data/groups/freshly";
 
             access = {
               A = [

--- a/systems/teal/copyparty.nix
+++ b/systems/teal/copyparty.nix
@@ -209,6 +209,34 @@
     };
     systemd.services.oauth2_proxy.preStart = "while [[ \"$(${pkgs.curl}/bin/curl -s -o /dev/null -w ''%{http_code}'' https://idm.freshly.space)\" != \"200\" ]]; do sleep 5; done";
 
+    services.headscale.settings.dns.extra_records = [
+      {
+        # files.freshly.space -> teal
+        name = "files.freshly.space";
+        type = "A";
+        value = "100.64.0.5";
+      }
+    ];
+    services.nginx.virtualHosts."internal.files.freshly.space" = {
+      listenAddresses = [ "100.64.0.5" ];
+
+      serverName = "files.freshly.space";
+
+      addSSL = true;
+      enableACME = true;
+      acmeRoot = null;
+
+      locations."/" = {
+        proxyPass = "http://127.0.0.1:1030";
+        recommendedProxySettings = true;
+        proxyWebsockets = true;
+      };
+    };
+    services.nginx.tailscaleAuth = {
+      enable = true;
+      virtualHosts = [ "internal.files.freshly.space" ];
+    };
+
     clicks.storage.impermanence.persist.directories = [ "/var/lib/copyparty" ];
   };
 }

--- a/systems/teal/copyparty.nix
+++ b/systems/teal/copyparty.nix
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  project,
+  config,
+  lib,
+  ...
+}:
+{
+  imports = [
+    project.inputs.copyparty.result.nixosModules.default
+  ];
+
+  config = {
+    nixpkgs.overlays = [ project.inputs.copyparty.result.overlays.default ];
+
+    services.copyparty =
+      let
+        admins = [
+          "coded"
+          "minion"
+        ];
+      in
+      {
+        enable = true;
+
+        settings = {
+          i = "127.0.0.1"; # ip
+          p = 1030; # port
+
+          # we'll be using nginx for this...
+          http-only = true;
+          no-crt = true;
+
+          idp-store = 3;
+
+          shr = "/share";
+          shr-db = "/var/lib/copyparty/shares.db";
+          shr-adm = admins;
+
+          # as we might have private directories, better to be a bit conservative about permissions...
+          chmod-f = 700;
+          chmod-d = 700;
+
+          magic = true; # "enable filetype detection on nameless uploads"
+
+          e2dsa = true; # index files to allow searching, upload undo, etc.
+          e2ts = true; # and scan metadata...
+
+          rss = true; # allow (experimental) rss support -> useful for antennapod/miniflux/co.
+          dav-auth = true; # "force auth for all folders" notably "(required by davfs2 when only some folders are world-readable)"
+
+          xvol = true; # don't allow symlinks to break out of confinement...
+          no-robots = true; # not really meant to be indexed. Maybe we want to add anubis at some point too...
+
+          ah-alg = "argon2";
+
+          og = true; # opengraph support for the benefit of Discord
+          og-ua = "Discordbot";
+          og-site = "Freshly Baked Cake Files";
+          spinner = "🧁"; # [hopefully this isn't too boring for you, tripflag](https://github.com/9001/copyparty/tree/hovudstraum/docs/rice#boring-loader-spinner)
+        };
+
+        accounts = {
+          coded.passwordFile = "/secrets/copyparty/default_password_coded";
+          minion.passwordFile = "/secrets/copyparty/default_password_minion";
+        };
+
+        volumes = {
+          "/" = {
+            path = "/var/lib/copyparty/data";
+
+            access = {
+              r = "*";
+              A = admins;
+            };
+          };
+          "/coded" = {
+            path = "/var/lib/copyparty/data/coded";
+
+            access = {
+              A = "coded";
+            };
+          };
+          "/minion" = {
+            path = "/var/lib/copyparty/data/minion";
+
+            access = {
+              A = "minion";
+            };
+          };
+          "/freshly" = {
+            path = "/var/lib/copyparty/data/freshly";
+
+            access = {
+              A = [
+                "coded"
+                "minion"
+              ];
+            };
+          };
+        };
+      };
+
+    systemd.services.copyparty.serviceConfig.StateDirectory =
+      "copyparty "
+      + (lib.pipe config.services.copyparty.volumes [
+        builtins.attrValues
+        (map (mount: mount.path))
+        (map (lib.removePrefix "/var/lib/"))
+        (lib.concatStringsSep " ")
+      ]);
+
+    services.nginx.enable = true;
+    services.nginx.virtualHosts."files.freshly.space" = {
+      addSSL = true;
+      enableACME = true;
+      acmeRoot = null;
+
+      locations."/" = {
+        proxyPass = "http://127.0.0.1:1030";
+        recommendedProxySettings = true;
+        proxyWebsockets = true;
+      };
+    };
+
+    clicks.storage.impermanence.persist.directories = [ "/var/lib/copyparty" ];
+  };
+}

--- a/systems/teal/default.nix
+++ b/systems/teal/default.nix
@@ -5,6 +5,7 @@
 {
   imports = [
     ./acme.nix
+    ./copyparty.nix
     ./fava.nix
     ./hardware-configuration.nix
     ./headscale.nix

--- a/systems/teal/fava.nix
+++ b/systems/teal/fava.nix
@@ -149,6 +149,8 @@ in
 
   services.nginx.enable = true;
   services.nginx.virtualHosts."fava.clicks.codes" = {
+    listenAddresses = [ "100.64.0.5" ];
+
     addSSL = true;
     enableACME = true;
     acmeRoot = null;

--- a/systems/teal/silverbullet.nix
+++ b/systems/teal/silverbullet.nix
@@ -26,6 +26,8 @@
 
   services.nginx.enable = true;
   services.nginx.virtualHosts."silverbullet.clicks.codes" = {
+    listenAddresses = [ "100.64.0.5" ];
+
     addSSL = true;
     enableACME = true;
     acmeRoot = null;


### PR DESCRIPTION
We've used Stalwart for files for a few days, and it is becoming clear that there are some problems for our use-case:
- Some clients we want to use don't support ACLs (see stalwartlabs/stalwart#1927)
- There's no way to do file sharing with anyone who we don't give a mail account
- Webdav is the only supported protocol (again, causing some trouble getting files on all devices)

Therefore we're trialing Copyparty. If it goes well, we'll block the /dav/file endpoint of Stalwart and switch over entirely