### PR TITLE
fix(copyparty): fix kanidm healthcheck

### DIFF
--- a/systems/teal/copyparty.nix
+++ b/systems/teal/copyparty.nix
@@ -205,7 +205,11 @@
         whitelist-domain = "files.freshly.space";
       };
     };
-    systemd.services.oauth2_proxy.preStart = "while [[ \"$(${pkgs.curl}/bin/curl -s -o /dev/null -w ''%{http_code}'' https://idm.freshly.space)\" != \"200\" ]]; do sleep 5; done";
+    systemd.services.oauth2-proxy = {
+      after = [ "kanidm.service" ];
+      requires = [ "kanidm.service" ];
+      preStart = "while [[ \"$(${pkgs.curl}/bin/curl -s -L https://idm.freshly.space/status)\" != \"true\" ]]; do sleep 5; done";
+    };
 
     services.headscale.settings.dns.extra_records = [
       {


### PR DESCRIPTION
Previously we were using some code from a previous incarnation of OAuth2 Proxy (from Clicks) to determine if kanidm was started.

Unfortunately this missed that oauth2_proxy was now known as oauth2-proxy so the health check was never getting activated.

Had it been activated we would also have seen that the default location is always a redirect. Instead, it's better to use the official status endpoint and check if it returns "true" (for "ready")