### PR TITLE
fix(copyparty): correct error on upload

### DIFF
--- a/systems/teal/copyparty.nix
+++ b/systems/teal/copyparty.nix
@@ -153,9 +153,9 @@
             end
 
             local Multipart = require("multipart")
-            local multipart_data = Multipart(body, headers["Content-Type"])
+            local multipart_data, err = pcall(Multipart(body, headers["Content-Type"]))
 
-            if multipart_data:get("act").value == "logout" then
+            if not err and multipart_data and multipart_data:get("act").value == "logout" then
               return ngx.redirect("https://files.freshly.space/oauth2/sign_out?rd=" .. ngx.var.scheme .. "://" .. ngx.var.host .. ngx.var.request_uri, ngx.HTTP_MOVED_TEMPORARILY)
             end
           }


### PR DESCRIPTION
Our lua parsing code has been broken when our multipart content can't be properly parsed: we've been getting errors like

    Aug 06 06:10:35 teal nginx[2647]: 2025/08/06 06:10:35 [error] 2647#2647: *4021 lua entry thread aborted: runtime error: access_by_lua(...ymhfpmsjqja9dc7k4pp9v54rc5z-nginx.conf:87):16: attempt to index a nil value
    Aug 06 06:10:35 teal nginx[2647]: stack traceback:
    Aug 06 06:10:35 teal nginx[2647]: coroutine 0:
    Aug 06 06:10:35 teal nginx[2647]:         access_by_lua(...ymhfpmsjqja9dc7k4pp9v54rc5z-nginx.conf:87): in main chunk while sending to client, client: 192.168.0.6, server: files.freshly.space, request: "GET /ws/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php HTTP/1.1", host: "71.246.21.254"

which we believe to be due to trying to read failed parsing (though we intend to test this PR very well before merging because that isn't the most helpful trace)