### PR TITLE
fix(packetmix): move impermanence into common

### DIFF
--- a/systems/common/packetmix.nix
+++ b/systems/common/packetmix.nix
@@ -44,4 +44,6 @@
   # Before changing this value read the documentation for this option
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
   system.stateVersion = "25.05";
+
+  clicks.storage.impermanence.persist.directories = [ "/etc/nixos" ];
 }

--- a/systems/teal/default.nix
+++ b/systems/teal/default.nix
@@ -12,7 +12,6 @@
     ./hostname.nix
     ./kanidm.nix
     ./networking.nix
-    ./packetmix.nix
     ./secrets.nix
     ./silverbullet.nix
     ./stalwart.nix

--- a/systems/teal/packetmix.nix
+++ b/systems/teal/packetmix.nix
@@ -1,7 +1,0 @@
-# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
-#
-# SPDX-License-Identifier: MIT
-
-{
-  clicks.storage.impermanence.persist.directories = [ "/etc/nixos" ];
-}


### PR DESCRIPTION
Previously the only impermanence stuff for packetmix was in teal. It should instead be in common as we now have systems that are not teal which are impermanent