### PR TITLE
fix(niri): enable gnome-keyring

### DIFF
--- a/homes/niri/ssh.nix
+++ b/homes/niri/ssh.nix
@@ -9,6 +9,7 @@
     Unit.After = [ "niri.service" ];
   };
 
+  services.gnome-keyring.enable = true;
   services.gnome-keyring.components = [
     "pkcs11"
     "secrets"


### PR DESCRIPTION
We have to disable the gnome keyring ssh support or we will sometimes get races that mean the ssh agent fails to start. Unfortunately, we weren't *actually* enabling the gnome-keyring service which meant the configuration was never actually used... oops