### PR TITLE
feat: increase soft file limit

### DIFF
--- a/systems/common/default.nix
+++ b/systems/common/default.nix
@@ -19,5 +19,6 @@
     ./sudo.nix
     ./sysctl.nix
     ./tailscale.nix
+    ./ulimit.nix
   ];
 }

--- a/systems/common/ulimit.nix
+++ b/systems/common/ulimit.nix
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Collabora Productivity Limited
+#
+# SPDX-License-Identifier: MIT
+
+{ ... }:
+{
+  systemd.user.extraConfig = ''
+    DefaultLimitNOFILE=65535
+  '';
+}


### PR DESCRIPTION
I'm having trouble building LibreOffice and Collabora since adding impermanence... my best guess is maybe impermanence uses more files than having it off - e.g. for FUSE?

Since `ulimit -n 65535` fixes the issue, it's probably worth making this permanent

If you try to do this, the first thing you'll find is `pam.loginLimits` buuuuuut that isn't actually respected, it turns out, as the systemd default overrides it (you can still manually override the limit but that is annoying). Oh well, got there eventually