### PR TITLE
fix(niri): start ssh agent after niri

### DIFF
--- a/homes/niri/ssh.nix
+++ b/homes/niri/ssh.nix
@@ -5,12 +5,7 @@
 { lib, ... }:
 {
   systemd.user.services.ssh-agent = {
-    Install.WantedBy = lib.mkForce [ "graphical-session.target" ];
+    Install.WantedBy = lib.mkForce [ "niri.service" ];
     Unit.After = [ "niri.service" ];
   };
-
-  services.gnome-keyring.components = [
-    "pkcs11"
-    "secrets"
-  ]; # all excluding ssh
 }


### PR DESCRIPTION
Previously we were having the ssh-agent after graphical-session.target, which sometimes seemed to work but mostly seemed to have dependency ordering issues. In a bid to fix this, we set up some systemd-keyring hacks (though seemed to fall short of actually setting .enable, presumably because of the intermittence of this problem) and were about to mask out the still-active systemd ssh keyring.

This, of course, would've been a mistake since as none of that was actually causing the issue.

Instead, the problem was that niri seems to start after graphical-session.target, we wanted to start after niri and were wantedBy graphical-session.target

No good, obviously.

We can also get rid of the inactive gnome-keyring code - it's doing nobody any good