### PR TITLE
fix(marbled): enable bolt

### DIFF
--- a/systems/marbled/hardware-configuration.nix
+++ b/systems/marbled/hardware-configuration.nix
@@ -65,4 +65,6 @@
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+  services.hardware.bolt.enable = true;
 }


### PR DESCRIPTION
Marbled was failing to use a USB mouse with the docking port; enable bolt to allow the docking port to be authorised.