### PR TITLE
feat(minion): set default browser

### DIFF
--- a/homes/minion/default.nix
+++ b/homes/minion/default.nix
@@ -15,5 +15,6 @@
     ./niri.nix
     ./prompt.nix
     ./ssh.nix
+    ./xdg.nix
   ];
 }

--- a/homes/minion/xdg.nix
+++ b/homes/minion/xdg.nix
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  xdg.mimeApps = {
+    enable = true;
+    defaultApplications = {
+      "default-web-browser" = [ "firefox.desktop" ];
+      "text/html" = [ "firefox.desktop" ];
+      "x-scheme-handler/http" = [ "firefox.desktop" ];
+      "x-scheme-handler/https" = [ "firefox.desktop" ];
+      "x-scheme-handler/about" = [ "firefox.desktop" ];
+      "x-scheme-handler/unknown" = [ "firefox.desktop" ];
+    };
+  };
+}


### PR DESCRIPTION
I want to use firefox as my default browser. Since switching to impermanence I haven't been saving my default apps and they have been decaying on every reboot. As there is hm-options for it, I should just be using those.