### PR TITLE
feat(teal): add routes to midnight

### DIFF
--- a/systems/teal/default.nix
+++ b/systems/teal/default.nix
@@ -12,6 +12,7 @@
     ./hostname.nix
     ./kanidm.nix
     ./networking.nix
+    ./midnight.nix
     ./secrets.nix
     ./silverbullet.nix
     ./stalwart.nix

--- a/systems/teal/midnight.nix
+++ b/systems/teal/midnight.nix
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  services.nginx.enable = true;
+  services.nginx.virtualHosts."login.clicks.codes" = {
+    addSSL = true;
+    enableACME = true;
+    acmeRoot = null;
+
+    serverAliases = [ "www.login.clicks.codes" ];
+
+    locations."/" = {
+      proxyPass = "https://100.64.0.11:443";
+      recommendedProxySettings = true;
+      proxyWebsockets = true;
+    };
+  };
+  services.nginx.virtualHosts."mail.clicks.codes" = {
+    addSSL = true;
+    enableACME = true;
+    acmeRoot = null;
+
+    serverAliases = [ "www.mail.clicks.codes" ];
+
+    locations."/" = {
+      proxyPass = "https://100.64.0.11:443";
+      recommendedProxySettings = true;
+      proxyWebsockets = true;
+    };
+  };
+}


### PR DESCRIPTION
We're going to switch over from sending traffic to midnight to sending it to teal. We still have a couple of things on midnight that we need to keep for a short amount of time. Therefore, we need to add routes back to them from teal to keep them running for now...