### PR TITLE
fix(kdiff3): use iso 8859-1 character encoding

### DIFF
--- a/homes/development/jujutsu.nix
+++ b/homes/development/jujutsu.nix
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Collabora Productivity Limited
 # SPDX-FileCopyrightText: 2025 FreshlyBakedCake
 #
 # SPDX-License-Identifier: MIT
@@ -322,6 +323,16 @@
             "WhiteSpaceEqual=0"
             "--cs"
             "UnfoldSubdirs=1"
+            "--cs"
+            "EncodingForA=iso 8859-1"
+            "--cs"
+            "EncodingForB=iso 8859-1"
+            "--cs"
+            "EncodingForC=iso 8859-1"
+            "--cs"
+            "EncodingForOutput=iso 8859-1"
+            "--cs"
+            "EncodingForPP=iso 8859-1"
             "$left"
             "$right"
           ];


### PR DESCRIPTION
kdiff3 has a broken UTF-8 encoding which saves invalid characters out if you have certain special characters in your file - even if they are on unmodified lines

This is clearly bad

Thankfully, we can workaround this by using iso 8859-1 encoding, which still doesn't display the characters correctly but also doesn't garble them on save. It'll display all ASCII and some unicode the same so is an acceptable substitute for the stuff we work on...

...you still can't insert *new* non-iso 8859-1 characters when diffediting/splitting/etc. but hey, "you can't have everything" (you can still copy lines that contain those incorrectly-displayed characters around and it'll work fine)