### PR TITLE
feat(jujutsu): add permitted SSH signers list

### DIFF
--- a/homes/coded/jujutsu.nix
+++ b/homes/coded/jujutsu.nix
@@ -18,7 +18,6 @@
       behavior = "drop";
       backend = "ssh";
       key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKpBNIHk/kRhQL7Nl3Fd+UBVRoS2bTpbeerA//vwL2D4 coded";
-      backends.ssh.allowed-signers = "~/.ssh/allowed_signers";
     };
     user = {
       name = "Samuel Shuert";

--- a/homes/default.nix
+++ b/homes/default.nix
@@ -19,6 +19,7 @@ in
       ./common
       ./development
       ./espanso
+      ./freshlybakedcake
       ./gaming
       ./maya
       (import ./niri { inherit (config.inputs) niri walker home-manager-unstable; })
@@ -40,6 +41,7 @@ in
       ./common
       ./development
       ./espanso
+      ./freshlybakedcake
       ./gaming
       ./minion
       (import ./niri { inherit (config.inputs) niri walker home-manager-unstable; })
@@ -62,6 +64,7 @@ in
       ./common
       ./development
       ./espanso
+      ./freshlybakedcake
       ./gaming
       ./minion
       (import ./niri { inherit (config.inputs) niri walker home-manager-unstable; })
@@ -85,6 +88,7 @@ in
       ./common
       ./development
       ./espanso
+      ./freshlybakedcake
       ./gaming
       (import ./niri { inherit (config.inputs) niri walker home-manager-unstable; })
       (import ./nix-index { inherit (config.inputs) nix-index-database; })
@@ -106,6 +110,7 @@ in
       ./common
       ./development
       ./espanso
+      ./freshlybakedcake
       ./gaming
       (import ./nix-index { inherit (config.inputs) nix-index-database; })
       ./remote

--- a/homes/freshlybakedcake/default.nix
+++ b/homes/freshlybakedcake/default.nix
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+{
+  imports = [ ./ssh.nix ];
+}

--- a/homes/freshlybakedcake/ssh.nix
+++ b/homes/freshlybakedcake/ssh.nix
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  # Non-packetmixers can be included in this list, but you should have a comment stating where you got the key/email(s) from
+  jujutsu.allowedSSHSigners = {
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKpBNIHk/kRhQL7Nl3Fd+UBVRoS2bTpbeerA//vwL2D4 coded" = [
+      "me@thecoded.prof"
+
+      "coded@clicks.codes"
+      "coded@coded.codes"
+      "coded@freshlybakedca.ke"
+      "samuel.shuert@gmail.com"
+    ];
+    "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIOMSUqXuH1bQZJc9rLV0H7/UY0c2BlkzAKWkwrXFWbQ7AAAABHNzaDo= ShorthairNanoResident" =
+      [
+        "me@thecoded.prof"
+
+        "coded@clicks.codes"
+        "coded@coded.codes"
+        "coded@freshlybakedca.ke"
+        "samuel.shuert@gmail.com"
+      ];
+    "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIOhzJ0p9bFRSURUjV05rrt5jCbxPXke7juNbEC9ZJXS/AAAAGXNzaDp0aW55X3l1YmlrZXlfcmVzaWRlbnQ= ssh:tiny_yubikey_resident" =
+      [
+        "sky@a.starrysky.fyi"
+
+        "minion@clicks.codes"
+        "minion@freshlybakedca.ke"
+        "minion@libreoffice.org"
+        "minion@trans.gg"
+        "skyler.grey@collabora.com"
+        "skyler3665@gmail.com"
+        "skyler3665@gmail.com"
+        "skyler@clicks.codes"
+      ];
+  };
+}


### PR DESCRIPTION
We have SSH keys for signing some commits, and it would be nice to have jujutsu automatically register them. This supersedes Coded's similar list as I adapted it from the allowed signers he already had

I've nixified it so that we have the principals as a list and I've added my own SSH signing key (just the one used for redhead as that's the one mentioned as a signer in my config - currently I'm not sure what to do about the lack of jj-vcs/jj#6688)

I've put it in a freshlybakedcake ingredient because it is a thing that people may consider if they want if they're not us - I don't believe any of the keys to be *wrong* but it is another measure of trust...

I haven't copied user keys here, if you have keys that you use to sign commits I advise you put them here yourself

I think we should add keys from outside PacketMix if we verify that they are correct (e.g. by getting the person who owns the email to say so over a trusted channel or seeing the "verified" badge for a particular key on GitHub)