### PR TITLE
fix(stalwart): quote http.url

### DIFF
--- a/systems/teal/stalwart.nix
+++ b/systems/teal/stalwart.nix
@@ -121,7 +121,7 @@ in
             };
           };
         };
-        http.url = "https://mail.freshly.space";
+        http.url = "'https://mail.freshly.space'";
         store.db = {
           type = "postgresql";
           host = "/run/postgresql";


### PR DESCRIPTION
We previously hadn't put http.url in single quotes since as that wasn't needed on the web UI. Unfortunately, it seems that in the configuration this is interpreted as an expression, breaking the URL if we don't put it in single quotes.

Coded did the investigation and I wrote the change here.