### PR TITLE
fix(fava): loosen requirement on nginx

### DIFF
--- a/systems/teal/fava.nix
+++ b/systems/teal/fava.nix
@@ -105,7 +105,7 @@ let
 in
 {
   systemd.services.fava = {
-    requires = [ "nginx.service" ];
+    wants = [ "nginx.service" ];
     after = [ "nginx.service" ];
     wantedBy = [ "multi-user.target" ];
 


### PR DESCRIPTION
fava can be running when nginx isn't up. Having nginx as a requires= dependency meant that whenever nginx configuration changed, fava would have to restart - that's not ideal, but moving it to wants= stops this being the case