### PR TITLE
feat(stalwart): add managesieve listener

### DIFF
--- a/systems/teal/stalwart.nix
+++ b/systems/teal/stalwart.nix
@@ -128,6 +128,14 @@ in
               bind = "127.0.0.1:1027";
               url = "https://mail.freshly.space";
             };
+            sieve = {
+              protocol = "managesieve";
+              bind = "0.0.0.0:4190";
+              tls = {
+                enable = true;
+                implicit = false; # We can't use =true as clients seem to not support it
+              };
+            };
           };
         };
         http.url = "'https://mail.freshly.space'";


### PR DESCRIPTION
Managesieve is used for users to manage sieve scripts: bits of code that decide what should happen to an email when it is recieved. They can do things like discarding mail from an address, filing mail in a specific folder, etc.

We need to open up the port without implicit TLS as sieve clients seem not to understand that...