### PR TITLE
feat: upgrade stalwart

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Evaluate all systems
         run: |
-          eval_out=$(nix-instantiate ./nilla.nix -A packages.allNixOSSystems.result.x86_64-linux --add-root ./system-root 2>&1 | tee /dev/stderr)
+          eval_out=$(nix-instantiate ./ci.nix -A packages.allNixOSSystems.result.x86_64-linux --add-root ./system-root 2>&1 | tee /dev/stderr)
           eval_warns=$(echo "$eval_out" | grep "evaluation warning:" || true)
 
           if [ -n "$eval_warns" ]; then
@@ -40,7 +40,7 @@ jobs:
 
       - name: Evaluate all homes
         run: |
-          eval_out=$(nix-instantiate ./nilla.nix -A packages.allNixOSSystems.result.x86_64-linux --add-root ./home-root 2>&1 | tee /dev/stderr)
+          eval_out=$(nix-instantiate ./ci.nix -A packages.allNixOSSystems.result.x86_64-linux --add-root ./home-root 2>&1 | tee /dev/stderr)
           eval_warns=$(echo "$eval_out" | grep "evaluation warning:" || true)
 
           if [ -n "$eval_warns" ]; then

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -52,10 +52,10 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Build all systems
-        run: nix build -f ./nilla.nix packages.allNixOSSystems.result.x86_64-linux --show-trace
+        run: nix build -f ./ci.nix packages.allNixOSSystems.result.x86_64-linux --show-trace
 
       - name: Build all homes
-        run: nix build -f ./nilla.nix packages.allHomes.result.x86_64-linux --show-trace
+        run: nix build -f ./ci.nix packages.allHomes.result.x86_64-linux --show-trace
 
       - if: github.event_name == 'push'
         name: Push to release branch

--- a/.github/workflows/treefmt.yaml
+++ b/.github/workflows/treefmt.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           set +e
 
-          nix-shell ./nilla.nix -A shells.default.result.x86_64-linux --run 'treefmt --ci'
+          nix-shell ./ci.nix -A shells.default.result.x86_64-linux --run 'treefmt --ci'
 
           exitCode=$?
 

--- a/.github/workflows/update-npins.yml
+++ b/.github/workflows/update-npins.yml
@@ -41,7 +41,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_TOKEN }}"
 
       - name: Run npins update
-        run: nix-shell ./nilla.nix -A shells.default.result.x86_64-linux --run 'npins update'
+        run: nix-shell ./ci.nix -A shells.default.result.x86_64-linux --run 'npins update'
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e

--- a/ci.nix
+++ b/ci.nix
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+let
+  base = import ./nilla.nix;
+  project = base.extend {
+    modules = [
+      (
+        { config, lib, ... }:
+        {
+          config.inputs = (
+            builtins.mapAttrs (
+              name: value:
+              if value ? settings.configuration.allowUnfree then
+                {
+                  settings.configuration = {
+                    allowUnfree = false;
+                    allowUnfreePredicate = (
+                      x: (x ? meta.license) && (x.meta.license.shortName == "unfreeRedistributable")
+                    ); # As we push to a public cachix, we can't use non-redistributable unfree software in CI
+                  };
+                }
+              else
+                { }
+            ) base.inputs
+          );
+        }
+      )
+      {
+        config.lib.ci = true;
+      }
+    ];
+  };
+in
+project.config // { inherit (project) extend; }

--- a/inputs.nix
+++ b/inputs.nix
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+let
+  pins = import ./npins;
+
+  settings = {
+    nixpkgs.configuration.allowUnfree = true;
+    "nixos-24.11" = settings.nixpkgs;
+    nixos-unstable = settings.nixpkgs;
+  };
+in
+{ config, ... }:
+{
+  config.inputs = builtins.mapAttrs (name: value: {
+    src = value;
+    settings = settings.${name} or config.lib.constants.undefined;
+  }) pins;
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,5 +4,6 @@
 
 { config, ... }:
 {
+  config.lib.ci = false;
   config.lib.constants.undefined = config.lib.modules.when false { };
 }

--- a/nilla.nix
+++ b/nilla.nix
@@ -8,9 +8,7 @@ let
   nilla = import pins.nilla;
 
   settings = {
-    nixpkgs.configuration.allowUnfreePredicate = (
-      x: (x ? meta.license) && (x.meta.license.shortName == "unfreeRedistributable")
-    ); # As we push to a public cachix, we can't use non-redistributable unfree software
+    nixpkgs.configuration.allowUnfree = true;
     "nixos-24.11" = settings.nixpkgs;
     nixos-unstable = settings.nixpkgs;
   };
@@ -20,6 +18,7 @@ nilla.create (
   {
     includes = [
       ./homes
+      ./inputs.nix
       ./lib
       ./packages
       ./systems
@@ -29,12 +28,6 @@ nilla.create (
     ];
 
     config = {
-      # Add Nixpkgs as an input (match the name you used when pinning).
-      inputs = builtins.mapAttrs (name: value: {
-        src = value;
-        settings = settings.${name} or config.lib.constants.undefined;
-      }) pins;
-
       packages.allNixOSSystems = {
         systems = [ "x86_64-linux" ];
 

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -299,23 +299,6 @@
       "url": "https://github.com/eewanco/scriptfs/archive/82d7e4865c9a8e40bc717c8745d052420365069c.tar.gz",
       "hash": "sha256-WLuOt8zemooHDzK+zWJNBicKu8bg0wXyAGvZIH/po6o="
     },
-    "stalwart": {
-      "type": "GitRelease",
-      "repository": {
-        "type": "GitHub",
-        "owner": "stalwartlabs",
-        "repo": "stalwart"
-      },
-      "pre_releases": false,
-      "version_upper_bound": null,
-      "release_prefix": null,
-      "submodules": false,
-      "version": "v0.13.1",
-      "revision": "00daa696080418c12715e58ee0561e0c90478084",
-      "url": "https://api.github.com/repos/stalwartlabs/stalwart/tarball/refs/tags/v0.13.1",
-      "hash": "sha256-6zoI+yvE1Ep5jh9XthDqphm2zBA4UzhfK7VCKRWIH8g=",
-      "frozen": true
-    },
     "treefmt-nix": {
       "type": "Git",
       "repository": {

--- a/systems/teal/stalwart.nix
+++ b/systems/teal/stalwart.nix
@@ -45,15 +45,11 @@ in
       enable = true;
       openFirewall = true;
 
-      package = project.inputs.nixos-unstable.result.x86_64-linux.stalwart-mail.overrideAttrs {
-        inherit (project.inputs.stalwart) src;
-        doCheck = false;
-        cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
-          name = "stalwart-deps";
-          inherit (project.inputs.stalwart) src;
-          hash = "sha256-t4BLko8vIVHZ44yeQoAhss3OxOlxJCErHm9h+FGG+28=";
-        };
-      };
+      package =
+        if project.lib.ci then
+          project.inputs.nixos-unstable.result.x86_64-linux.stalwart-mail
+        else
+          project.inputs.nixos-unstable.result.x86_64-linux.stalwart-mail-enterprise;
 
       settings = {
         config.local-keys = [


### PR DESCRIPTION
We've kept stalwart pinned at 0.13.0 for a little while since as we
needed some features from it before nixpkgs had it. Nixpkgs is now on
0.13.2, so we should be using it instead. We don't want to upgrade just
to 0.13.2 though, since as we are paying for stalwart enterprise - let's
use enterprise stalwart when we're not in CI.