### PR TITLE
fix(copyparty): make tailscale auth work again

### DIFF
--- a/systems/teal/copyparty.nix
+++ b/systems/teal/copyparty.nix
@@ -135,6 +135,11 @@
       }"; # The double-semicolon makes the default search paths also be included
     '';
     services.nginx.virtualHosts."files.freshly.space" = {
+      listenAddresses = [
+        "0.0.0.0"
+        "[::0]"
+      ];
+
       addSSL = true;
       enableACME = true;
       acmeRoot = null;
@@ -238,7 +243,7 @@
       }
     ];
     services.nginx.virtualHosts."internal.files.freshly.space" = {
-      listenAddresses = [ "100.64.0.5" ];
+      listenAddresses = [ "localhost.tailscale" ];
 
       serverName = "files.freshly.space";
 


### PR DESCRIPTION
This is a regression from upuvkmrlstxkxpptssslvyrvvwnwosmt (commit 4de3921b846818357f0b79960b575b7db3f71043)

In it, we changed the default listener IP to include tailscale IPs, but this meant that the main copyparty listener was used rather than the tailscale-authed one. Explicitly specifying that the tailscale-authed listener should listen on the tailscale IP and that the main listener should only listen on 0.0.0.0 fixes this.