### PR TITLE
fix(headscale): stop requesting email scope

### DIFF
--- a/systems/teal/headscale.nix
+++ b/systems/teal/headscale.nix
@@ -130,10 +130,9 @@ in
         pkce.enabled = true;
 
         scope = [
-          "openid"
-          "email"
-          "profile"
           "groups"
+          "openid"
+          "profile"
         ];
       };
     };


### PR DESCRIPTION
If headscale has an email for a user, it'll use the local part as the username. This wasn't a problem when that was the same but as we're making some users' primary emails not have their username as the local part (e.g. minion@clicks.codes -> sky@a.starrysky.fyi) this is now causing trouble