### PR TITLE
fix(scriptfs): break starting loop

### DIFF
--- a/homes/niri/default.nix
+++ b/homes/niri/default.nix
@@ -11,6 +11,7 @@
   imports = [
     (import ./niri.nix { inherit niri walker; })
     (import ./quickshell { inherit home-manager-unstable; })
+    ./scriptfs.nix
     ./ssh.nix
     ./swaync.nix
   ];

--- a/homes/niri/niri.nix
+++ b/homes/niri/niri.nix
@@ -373,16 +373,5 @@
         Slice = "session.slice";
       };
     };
-
-    systemd.user.services.scriptfs = {
-      Install.WantedBy = lib.mkForce [ "graphical-session.target" ];
-
-      Unit = {
-        PartOf = "graphical-session.target";
-        After = [
-          "niri.service"
-        ];
-      };
-    };
   };
 }

--- a/homes/niri/scriptfs.nix
+++ b/homes/niri/scriptfs.nix
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ lib, ... }:
+{
+  systemd.user.services.scriptfs = {
+    Install.WantedBy = lib.mkForce [ "niri.service" ];
+    Unit.After = [ "niri.service" ];
+  };
+}


### PR DESCRIPTION
When I added scriptfs, I incorrectly started it similarly to xdg-desktop-portal. Instead, I meant to start it like we do the ssh-agent: both exclusively WantedBy and After niri. This avoids the start loop with systemd secrets stuff...