### PR TITLE
feat(espanso): persist matches directory

### DIFF
--- a/homes/espanso/espanso.nix
+++ b/homes/espanso/espanso.nix
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Collabora Productivity Limited
 # SPDX-FileCopyrightText: 2025 FreshlyBakedCake
 #
 # SPDX-License-Identifier: MIT
@@ -32,4 +33,8 @@
         { }
     )
   );
+
+  clicks.storage.impermanence.persist.directories = [
+    ".config/espanso/match"
+  ];
 }


### PR DESCRIPTION
I have some matches that I want to control out-of-band on PacketMixed machines:
- Matches that can't be placed in a public GitHub repository
- Espanso hub packages which I want to install without controlling them in PacketMix

While the recommended method for adding matches is still PacketMix config - after all, your matches can't follow you/etc. if they aren't updated along with your system - we may as well give impermanence users like myself the choice to install matches imperatively also