### PR TITLE
fix(quickshell): move out of subdirectory

### DIFF
--- a/homes/niri/quickshell.nix
+++ b/homes/niri/quickshell.nix
@@ -21,14 +21,14 @@
     configs.sprinkles = pkgs.stdenv.mkDerivation {
       name = "sprinkles-config";
 
-      src = ./.;
+      src = ./quickshell;
       dontUnpack = true;
 
       buildPhase = ''
         mkdir -p $out
 
         cp -r $src/*.qml $out
-        cp ${config.niri.overviewBackground} $out/background.png
+        cp ${config.ingredient.niri.niri.overviewBackground} $out/background.png
       '';
     };
 


### PR DESCRIPTION
When we implemented ingredients, we accidentally left quickshell in a subdirectory where it'd never be used...

...that led to our overview background, time and battery indicators being missing since as the code to display them was never imported...

...oops