### PR TITLE
feat: add nightshift

### DIFF
--- a/homes/default.nix
+++ b/homes/default.nix
@@ -42,6 +42,7 @@ in
       "espanso"
       "freshlybakedcake"
       "gaming"
+      "nightshift"
       "nix-index"
       "remote"
     ];
@@ -63,6 +64,7 @@ in
       "espanso"
       "freshlybakedcake"
       "gaming"
+      "nightshift"
       "nix-index"
       "remote"
     ];

--- a/homes/nightshift/gammastep.nix
+++ b/homes/nightshift/gammastep.nix
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  services.gammastep = {
+    enable = true;
+    provider = "geoclue2";
+  };
+}

--- a/systems/default.nix
+++ b/systems/default.nix
@@ -15,6 +15,7 @@ in
       "freshlybakedcake"
       "javelin"
       "minion"
+      "nightshift"
       "niri"
       "personal"
       "portable"
@@ -33,6 +34,7 @@ in
       "gaming"
       "javelin"
       "minion"
+      "nightshift"
       "niri"
       "personal"
     ];

--- a/systems/nightshift/geoclue2.nix
+++ b/systems/nightshift/geoclue2.nix
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  services.geoclue2.enable = true;
+}


### PR DESCRIPTION
I often use computers fairly late - it's nice to have my display turn a little less blue at night. Here's an ingredient to do that!

I considered having this as some sort of 'nightshift+niri', since as I am using gammastep which is wayland only, but then I realized that all supported desktop systems use wayland so it doesn't really matter. If someone uses an X system later they may want to factor this out...

The fact that nightshift relies on system geoclue2 is yet another nail in the "we should be determining system ingredients from your homes" coffin...