### PR TITLE
feat(minion): add brightnessctl

### DIFF
--- a/homes/redhead/misc.nix
+++ b/homes/redhead/misc.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, ... }:
+{
+  # Miscellaneous package installs that aren't really big enough to get their own folder
+  # Don't place any config that isn't directly adding lines to home.packages here...
+  home.packages = [
+    pkgs.brightnessctl
+  ];
+}


### PR DESCRIPTION
I continually end up installing this one to mess with my laptop brightness... probably worth just installing it in a misc.nix. I don't want to use homes/minion/misc.nix since as I don't *use* it on emden, so best to just give redhead a misc of its own...