### PR TITLE
fix(niri): start walker with a systemd service

### DIFF
--- a/homes/niri/niri.nix
+++ b/homes/niri/niri.nix
@@ -12,7 +12,6 @@
 {
   imports = [
     project.inputs.niri.result.homeModules.niri
-    project.inputs.walker.result.homeManagerModules.walker
   ];
 
   options.ingredient.niri.niri = {
@@ -140,8 +139,6 @@
 
               "${mod}+Space".action.switch-layout = [ "next" ];
               "${mod}+Shift+Space".action.switch-layout = [ "prev" ];
-
-              "${mod}+D".action.spawn = "${config.programs.walker.package}/bin/walker";
 
               "${mod}+Shift+Slash".action.show-hotkey-overlay = [ ];
 
@@ -309,11 +306,6 @@
             }
             {
               command = [
-                "${project.inputs.walker.result.inputs.elephant.packages.${pkgs.system}.default}/bin/elephant"
-              ];
-            }
-            {
-              command = [
                 "${pkgs.swaybg}/bin/swaybg"
                 "-i"
                 "${config.ingredient.niri.niri.wallpaper}"
@@ -340,8 +332,6 @@
           ];
         };
       };
-
-    programs.walker.enable = true;
 
     programs.bash.profileExtra = lib.mkBefore ''
       if [ -z $WAYLAND_DISPLAY ] && [ "$(tty)" = "/dev/tty1" ]; then

--- a/homes/niri/walker.nix
+++ b/homes/niri/walker.nix
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT
+
+{
+  project,
+  config,
+  options,
+  lib,
+  ...
+}:
+{
+  imports = [
+    project.inputs.walker.result.homeManagerModules.walker
+  ];
+
+  config = {
+    programs.niri.settings.binds."Mod+D".action.spawn = "${config.programs.walker.package}/bin/walker";
+
+    programs.walker = {
+      enable = true;
+      runAsService = true;
+    };
+    programs.elephant.providers =
+      let
+        allProviders = options.programs.elephant.providers.type.nestedTypes.elemType.functor.payload.values;
+        disabledProviders = [
+          "files" # disabled because this forces us to index every file in home - which can get ridiculously slow with, e.g., LibreOffice clones
+        ];
+      in
+      builtins.filter (name: !(builtins.elem name disabledProviders)) allProviders;
+
+    systemd.user.services.elephant.Unit.After = [ "niri.service" ];
+    systemd.user.services.walker.Unit.After = [ "niri.service" ];
+    systemd.user.services.elephant.Unit.WantedBy = lib.mkForce [ "niri.service" ];
+    systemd.user.services.walker.Unit.WantedBy = lib.mkForce [ "niri.service" ];
+    systemd.user.services.elephant.Unit.PartOf = lib.mkForce [ ];
+    systemd.user.services.walker.Unit.PartOf = lib.mkForce [ ];
+  };
+}


### PR DESCRIPTION
Coded added a stopgap solution for walker starting before elephant. We were still getting pretty bad startup performance, though, so I looked into it.

It turned out a variety of things were needed to start walker faster:
- Moving to a systemd service was helpful, but only once walker had started once, otherwise the socket would never connect and walker wouldn't open at all
- Disabling file indexing by default was necessary for systems with lots of files in home (for example LibreOffice clones). If you want to add file indexing back for yourself, I recommend you figure out where your large files are and use '.ignore' files (.gitignore syntax) to ignore them
- Elephant needed to be started properly - after niri so WAYLAND_DISPLAY was set but not in the ordering cycle on graphical-session.target. I used the same settings as we have for ssh-agent, say

Because of all of this, I also factored walker out into its own file.

This additionally marks

- The first keybind moved outside of the niri.nix file
- The first keybind to be created with Mod rather than ${mod} (= Super)

While it's a bit of a shame to not have all the keybindings in the same place, I think it's worth it...