### PR TITLE
fix(niri): correct walker services WantedBy

### DIFF
--- a/homes/niri/walker.nix
+++ b/homes/niri/walker.nix
@@ -32,8 +32,8 @@
 
     systemd.user.services.elephant.Unit.After = [ "niri.service" ];
     systemd.user.services.walker.Unit.After = [ "niri.service" ];
-    systemd.user.services.elephant.Unit.WantedBy = lib.mkForce [ "niri.service" ];
-    systemd.user.services.walker.Unit.WantedBy = lib.mkForce [ "niri.service" ];
+    systemd.user.services.elephant.Install.WantedBy = lib.mkForce [ "niri.service" ];
+    systemd.user.services.walker.Install.WantedBy = lib.mkForce [ "niri.service" ];
     systemd.user.services.elephant.Unit.PartOf = lib.mkForce [ ];
     systemd.user.services.walker.Unit.PartOf = lib.mkForce [ ];
   };


### PR DESCRIPTION
This fixes a regression from tqywkonpmxyulxkyuyusqntrwomtkkxu (9d7dfaabeb1b2cf9ddb4219a064e75b270b7926a). I accidentally put the WantedBy in the Unit section rather than the Install section. This left the unit starting on graphical-session.target rather than niri.service, which prevented it starting due to the ordering loop...

...oops