### PR TITLE
feat(headscale): defer auth to device registration

### DIFF
--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner>. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -94,6 +94,19 @@
       "url": "https://api.github.com/repos/9001/copyparty/tarball/refs/tags/v1.19.8",
       "hash": "sha256-S7HDDX3ndcMo++d9mEBw74LJqwoivP3XB42RgeqYX+E="
     },
+    "headscale": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "juanfont",
+        "repo": "headscale"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "30d12dafed210316431a57349adfdb2128078feb",
+      "url": "https://github.com/juanfont/headscale/archive/30d12dafed210316431a57349adfdb2128078feb.tar.gz",
+      "hash": "sha256-q2Ac/KfHv9WWZVHo+AM4opt3P7iFqO4XsbtRTpGIPU0="
+    },
     "home-manager": {
       "type": "Git",
       "repository": {

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -9,6 +9,7 @@
     ./beancount-beancount_share
     ./beancount-smart_importer
     ./collabora-gtimelog
+    ./headscale
     ./jujutsu
     ./lua-multipart
     ./OpenLinkHub

--- a/packages/headscale/default.nix
+++ b/packages/headscale/default.nix
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2020 Juan Font
+# SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+#
+# SPDX-License-Identifier: MIT and BSD-3-Clause
+
+{ config, ... }:
+{
+  config.packages.headscale = {
+    systems = [ "x86_64-linux" ];
+    package =
+      {
+        lib,
+        buildGo124Module,
+        ...
+      }:
+      let
+        vendorHash = "sha256-hIY6asY3rOIqf/5P6lFmnNCDWcqNPJaj+tqJuOvGJlo=";
+        commitHash = config.inputs.headscale.src.revision;
+        headscaleVersion = commitHash;
+      in
+      buildGo124Module {
+        pname = "headscale";
+        version = headscaleVersion;
+        src = config.inputs.headscale.src;
+
+        # Only run unit tests when testing a build
+        checkFlags = [ "-short" ];
+
+        # When updating go.mod or go.sum, a new sha will need to be calculated,
+        # update this if you have a mismatch after doing a change to those files.
+        inherit vendorHash;
+
+        subPackages = [ "cmd/headscale" ];
+
+        patches = [ ./deferred-auth.patch ];
+
+        ldflags = [
+          "-s"
+          "-w"
+          "-X github.com/juanfont/headscale/hscontrol/types.Version=${headscaleVersion}"
+          "-X github.com/juanfont/headscale/hscontrol/types.GitCommitHash=${commitHash}"
+        ];
+
+        meta = {
+          mainProgram = "headscale";
+          maintainer = [ lib.maintainers.minion3665 ];
+        };
+      };
+  };
+}

--- a/packages/headscale/deferred-auth.patch
+++ b/packages/headscale/deferred-auth.patch
@@ -1,0 +1,188 @@
+Commit ID: 9803b8ce2460772ba0eaae7b245d10009ba6a00b
+Change ID: rmzrrlvnpvlukyuotstptzuvnkvkssps
+Bookmarks: private/minion/push-rmzrrlvnpvlu private/minion/push-rmzrrlvnpvlu@git private/minion/push-rmzrrlvnpvlu@origin
+Author   : Skyler Grey <minion@freshlybakedca.ke> (2025-09-13 14:04:34)
+Committer: Skyler Grey <minion@freshlybakedca.ke> (2025-09-13 14:41:03)
+Signature: good signature by sky@a.starrysky.fyi
+
+    oidc: allow deferring auth provider setup
+
+    Currently, if Headscale fails to set up OIDC when it is starting up
+    there are two cases. Either:
+    - only_start_if_oidc_is_available is true and Headscale fails to start
+    - only_start_if_oidc_is_available is false and Headscale disables OIDC
+      until it is restarted
+
+    In our setup, we rely on Headscale for any remote SSH access. As most
+    users don't have any physical access we can't afford to have Headscale
+    fail to start. This, however, means that if Headscale starts without our
+    auth provider having yet started (as frequently happens) we will not be
+    able to authenticate via OIDC until we restart headscale.
+
+    This patch adds a new config option ('auth_setup_allow_defer') to soft
+    fail on setting up OIDC until we attempt registration. At that point if
+    OIDC still doesn't work authentication will fail (i.e. there will not be
+    the option to login via the command line)
+
+    fixes: juanfont/headscale#1873
+
+diff --git a/hscontrol/app.go b/hscontrol/app.go
+index 6880c6bed8..152d014a69 100644
+--- a/hscontrol/app.go
++++ b/hscontrol/app.go
+@@ -112,6 +112,40 @@
+ 	dumpConfig       = envknob.Bool("HEADSCALE_DEBUG_DUMP_CONFIG")
+ )
+ 
++func (h *Headscale) InitOrGetAuthProvider(ctx context.Context) (*AuthProvider, error) {
++	if h.authProvider != nil {
++		return &h.authProvider, nil
++	}
++
++	var authProvider AuthProvider
++	authProvider = NewAuthProviderWeb(h.cfg.ServerURL)
++	if h.cfg.OIDC.Issuer != "" {
++		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
++		defer cancel()
++		oidcProvider, err := NewAuthProviderOIDC(
++			ctx,
++			h,
++			h.cfg.ServerURL,
++			&h.cfg.OIDC,
++		)
++		if err != nil {
++			if h.cfg.OIDC.OnlyStartIfOIDCIsAvailable {
++				return nil, err
++			} else if h.cfg.AuthSetupAllowDefer {
++				log.Warn().Err(err).Msg("failed to set up OIDC provider, deferring until I get an auth request")
++				authProvider = nil
++			} else {
++				log.Warn().Err(err).Msg("failed to set up OIDC provider, falling back to CLI based authentication")
++			}
++		} else {
++			authProvider = oidcProvider
++		}
++	}
++	h.authProvider = authProvider
++
++	return &h.authProvider, nil
++}
++
+ func NewHeadscale(cfg *types.Config) (*Headscale, error) {
+ 	var err error
+ 	if profilingEnabled {
+@@ -155,28 +189,10 @@
+ 	})
+ 	app.ephemeralGC = ephemeralGC
+ 
+-	var authProvider AuthProvider
+-	authProvider = NewAuthProviderWeb(cfg.ServerURL)
+-	if cfg.OIDC.Issuer != "" {
+-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+-		defer cancel()
+-		oidcProvider, err := NewAuthProviderOIDC(
+-			ctx,
+-			&app,
+-			cfg.ServerURL,
+-			&cfg.OIDC,
+-		)
+-		if err != nil {
+-			if cfg.OIDC.OnlyStartIfOIDCIsAvailable {
+-				return nil, err
+-			} else {
+-				log.Warn().Err(err).Msg("failed to set up OIDC provider, falling back to CLI based authentication")
+-			}
+-		} else {
+-			authProvider = oidcProvider
+-		}
++	_, err = app.InitOrGetAuthProvider(context.Background())
++	if err != nil {
++		return nil, err
+ 	}
+-	app.authProvider = authProvider
+ 
+ 	if app.cfg.TailcfgDNSConfig != nil && app.cfg.TailcfgDNSConfig.Proxied { // if MagicDNS
+ 		// TODO(kradalby): revisit why this takes a list.
+@@ -455,12 +471,37 @@
+ 	router.HandleFunc("/robots.txt", h.RobotsHandler).Methods(http.MethodGet)
+ 	router.HandleFunc("/health", h.HealthHandler).Methods(http.MethodGet)
+ 	router.HandleFunc("/key", h.KeyHandler).Methods(http.MethodGet)
+-	router.HandleFunc("/register/{registration_id}", h.authProvider.RegisterHandler).
++	router.HandleFunc("/register/{registration_id}", func(writer http.ResponseWriter, req *http.Request) {
++		authProvider, err := h.InitOrGetAuthProvider(req.Context())
++		if authProvider == nil {
++			log.Warn().Err(err).Msg("failed to setup auth on registration request")
++			writer.WriteHeader(http.StatusInternalServerError)
++			return
++		}
++
++		h.authProvider.RegisterHandler(writer, req)
++	}).
+ 		Methods(http.MethodGet)
+ 
+-	if provider, ok := h.authProvider.(*AuthProviderOIDC); ok {
+-		router.HandleFunc("/oidc/callback", provider.OIDCCallbackHandler).Methods(http.MethodGet)
+-	}
++	router.HandleFunc("/oidc/callback", func(writer http.ResponseWriter, req *http.Request) {
++		if h.cfg.OIDC.Issuer == "" {
++			writer.WriteHeader(http.StatusNotFound)
++			return
++		}
++
++		authProvider, err := h.InitOrGetAuthProvider(req.Context())
++		if authProvider == nil {
++			log.Warn().Err(err).Msg("failed to setup auth on registration request")
++			return
++		}
++
++		if provider, ok := (*authProvider).(*AuthProviderOIDC); ok {
++			provider.OIDCCallbackHandler(writer, req)
++			return
++		}
++
++		writer.WriteHeader(http.StatusInternalServerError)
++	}).Methods(http.MethodGet)
+ 	router.HandleFunc("/apple", h.AppleConfigMessage).Methods(http.MethodGet)
+ 	router.HandleFunc("/apple/{platform}", h.ApplePlatformConfig).
+ 		Methods(http.MethodGet)
+diff --git a/hscontrol/auth.go b/hscontrol/auth.go
+index 81032640ce..9c018da908 100644
+--- a/hscontrol/auth.go
++++ b/hscontrol/auth.go
+@@ -266,7 +266,13 @@
+ 
+ 	log.Info().Msgf("Starting node registration using key: %s", registrationId)
+ 
++	authProvider, err := h.InitOrGetAuthProvider(context.Background())
++	if authProvider == nil {
++		log.Error().Err(err).Msg("Failed to get auth provider when registering node")
++		return nil, fmt.Errorf("getting auth provider when registering node: %w", err)
++	}
++
+ 	return &tailcfg.RegisterResponse{
+-		AuthURL: h.authProvider.AuthURL(registrationId),
++		AuthURL: (*authProvider).AuthURL(registrationId),
+ 	}, nil
+ }
+diff --git a/hscontrol/types/config.go b/hscontrol/types/config.go
+index 4a0a366eb2..18227d391f 100644
+--- a/hscontrol/types/config.go
++++ b/hscontrol/types/config.go
+@@ -88,7 +88,8 @@
+ 	UnixSocket           string
+ 	UnixSocketPermission fs.FileMode
+ 
+-	OIDC OIDCConfig
++	AuthSetupAllowDefer bool
++	OIDC                OIDCConfig
+ 
+ 	LogTail             LogTailConfig
+ 	RandomizeClientPort bool
+@@ -941,6 +942,7 @@
+ 		UnixSocket:           viper.GetString("unix_socket"),
+ 		UnixSocketPermission: util.GetFileMode("unix_socket_permission"),
+ 
++		AuthSetupAllowDefer: viper.GetBool("auth_setup_allow_defer"),
+ 		OIDC: OIDCConfig{
+ 			OnlyStartIfOIDCIsAvailable: viper.GetBool(
+ 				"oidc.only_start_if_oidc_is_available",

--- a/packages/headscale/deferred-auth.patch.license
+++ b/packages/headscale/deferred-auth.patch.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2020 Juan Font
+SPDX-FileCopyrightText: 2025 FreshlyBakedCake
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/systems/teal/headscale.nix
+++ b/systems/teal/headscale.nix
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ pkgs, ... }:
+{ project, pkgs, ... }:
 let
   groups = {
     /**
@@ -20,12 +20,13 @@ let
       different permission level. Servers can only access other servers
     */
     "group:users" = [
-      "coded"
-      "matei"
-      "minion"
-      "mostlyturquoise"
-      "pinea"
-      "zanderp25"
+      "coded@"
+      "matei@"
+      "minion@"
+      "mostlyturquoise@"
+      "pinea@"
+      "zanderp25@"
+      "testminion@"
     ];
 
     /**
@@ -36,21 +37,16 @@ let
       tailnet
     */
     "group:friends" = [
-      "sirdigalot"
+      "sirdigalot@"
     ];
   };
 
   exceptional_acls = [
     {
       action = "accept";
-      src = [ "zulu" ];
-      dst = [ "zanderp25:3000" ];
-    } # Used to let Zan reverse proxy to their personal machine for development - port-locked so probably OK
-    {
-      action = "accept";
       src = [
-        "mostlyturquoise"
-        "starrylee"
+        "mostlyturquoise@"
+        "starrylee@"
       ];
       dst = [ "tag:mostlyturquoise-minecraft-server:*" ];
     } # Used to let mostlyturquoise and their friends access their minecraft servers without giving people too many permissions
@@ -85,13 +81,20 @@ let
 
   tagOwners = {
     "tag:server" = [ "group:users" ];
-    "tag:mostlyturquoise-minecraft-server" = [ "mostlyturquoise" ];
+    "tag:mostlyturquoise-minecraft-server" = [ "mostlyturquoise@" ];
   };
 in
 {
+  disabledModules = [ "services/networking/headscale.nix" ];
+  imports = [
+    "${project.inputs.nixos-unstable.src}/nixos/modules/services/networking/headscale.nix"
+  ];
+
   # Headscale service
   services.headscale = {
     enable = true;
+
+    package = project.packages.headscale.result.x86_64-linux;
 
     address = "127.0.0.1";
     port = 1024;
@@ -116,9 +119,9 @@ in
         ];
         base_domain = "clicks.domains";
       };
+      auth_setup_allow_defer = true; # Otherwise we'll fall back to CLI auth
       oidc = {
         only_start_if_oidc_is_available = false; # Otherwise we can end up locking ourselves out...
-        strip_email_domain = true;
 
         issuer = "https://idm.freshly.space/oauth2/openid/headscale";
 


### PR DESCRIPTION
When we start up headscale, it tries to connect to OIDC. If our OIDC server is down, there were previously two options:
- We can fail to start the server altogether
- We can fallback to CLI auth and lose the ability to use OIDC until headscale is restarted

Neither of these are what I want: I want us to start up anyway but not allow registration until OIDC successfully connects

I've made a patch to do just that! I made it ontop of main, so I've also had to upgrade headscale to allow use of this patch.

I had some troubles with nilla, which can't properly interpret the headscale flake (missing rev/shortRev attributes) - therefore I've taken the nix package definition from the headscale repo and updated it to use the patch and the correct source manually

Refs: juanfont/headscale#1873