### PR TITLE
feat!: migrate to tangled.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ SPDX-FileCopyrightText: 2025 FreshlyBakedCake
 SPDX-License-Identifier: MIT
 -->
 
+> [!IMPORTANT]
+> PacketMix has moved! You can find us [on Tangled](https://tangled.org/@freshlybakedca.ke/patisserie/)
+
 # PacketMix
 
 # Principles

--- a/systems/common/packetmix.nix
+++ b/systems/common/packetmix.nix
@@ -6,9 +6,11 @@
 { config, pkgs, ... }:
 {
   nix.settings.substituters = [
+    "https://cache.freshlybakedca.ke"
     "https://freshlybakedcake.cachix.org"
   ];
   nix.settings.trusted-public-keys = [
+    "cache.freshlybakedca.ke-1:WD7CED6MwAxxOzgHlrHVbcVdYeqSa2mwBwR3vNuCJvg="
     "freshlybakedcake.cachix.org-1:YmhsHdeKjqbaS33PPJXJllTHBupT3hliQrPcllJXkE0="
   ];
 
@@ -26,6 +28,7 @@
   systemd.services.nixos-upgrade.preStart = ''
     ${pkgs.networkmanager}/bin/nm-online -s -q # wait until the internet is online, as esp. if we go offline we need to wait to retry...
     cd /etc/nixos
+    ${pkgs.git}/bin/git remote set-url origin https://git.freshlybakedca.ke/patisserie.git:workspace=packetmix.git
     ${pkgs.git}/bin/git fetch
     ${pkgs.git}/bin/git checkout origin/release
   '';


### PR DESCRIPTION
We've moved our repository to https://tangled.org. In-fact, we're using a monorepo of which packetmix is a single part, and we have a josh proxy ready to clone down just the packetmix part of the repository.

Thanks for being with us on GitHub - we hope to see you on Tangled!